### PR TITLE
Rename Gitea across the API to AllSpice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A very simple API client for AllSpice Hub
 
-Note that not the full Swagger-API is accessible. The whole implementation is focused 
+Note that not the full Swagger-API is accessible. The whole implementation is focused
 on making access and working with Organizations, Teams, Repositories and Users as pain
 free as possible.
 
@@ -10,42 +10,46 @@ Forked from https://github.com/Langenfeld/py-gitea.
 
 ## Usage
 
-First get an `allspice` object wrapping access and authentication (via an api token) for your gitea instance:
+First get an `allspice_client` object wrapping access and authentication (via an api token) for your instance of AllSpice Hub.
 
 ```python
-from gitea import *
+from allspice import *
 
-allspice = Gitea(URL, TOKEN)
+# By default, points to hub.allspice.io.
+allspice_client = AllSpice(token_text=TOKEN)
+
+# If you are self-hosting:
+allspice_client = AllSpice(allspice_hub_url=URL, token_text=TOKEN)
 ```
 
-Operations like requesting the Allspice version or authentication user can be requested directly from the `allspice` object:
+Operations like requesting the AllSpice version or authentication user can be requested directly from the `allspice_client` object:
 
 ```python
-print("AllSpice Version: " + allspice.get_version())
-print("API-Token belongs to user: " + allspice.get_user().username)
+print("AllSpice Version: " + allspice_client.get_version())
+print("API-Token belongs to user: " + allspice_client.get_user().username)
 ```
 
-Adding entities like Users, Organizations, ...  also is done via the allspice object.
+Adding entities like Users, Organizations, ...  also is done via the allspice_client object.
 
 ```python
-user = allspice.create_user("Test Testson", "test@test.test", "password")
+user = allspice_client.create_user("Test Testson", "test@test.test", "password")
 ```
 
 All operations on entities in allspice are then accomplished via the according wrapper objects for those entities.
-Each of those objects has a `.request` method that creates an entity according to your allspice instance. 
+Each of those objects has a `.request` method that creates an entity according to your allspice_client instance.
 
 ```python
-other_user = User.request(allspice, "OtherUserName")
+other_user = User.request(allspice_client, "OtherUserName")
 print(other_user.username)
 ```
 
-Note that the fields of the User, Organization,... classes are dynamically created at runtime, and thus not visible during divelopment. Refer to the AllSpice-API documentation for the fields names. 
+Note that the fields of the User, Organization,... classes are dynamically created at runtime, and thus not visible during divelopment. Refer to the AllSpice API documentation for the fields names.
 
 
-Fields that can not be altered via allspice-api, are read only. After altering a field, the `.commit` method of the according object must be called to synchronize the changed fields with your allspice instance.
+Fields that can not be altered via allspice-api, are read only. After altering a field, the `.commit` method of the according object must be called to synchronize the changed fields with your allspice_client instance.
 
 ```python
-org = Organization.request(allspice, test_org)
+org = Organization.request(allspice_client, test_org)
 org.description = "some new description"
 org.location = "some new location"
 org.commit()
@@ -56,9 +60,9 @@ An entity in allspice can be deleted by calling delete.
 org.delete()
 ```
 
-All entity objects do have methods to execute some of the requests possible though the allspice-api:
+All entity objects do have methods to execute some of the requests possible though the AllSpice api:
 ```python
-org = Organization.request(allspice, ORGNAME)
+org = Organization.request(allspice_client, ORGNAME)
 teams = org.get_teams()
 for team in teams:
 	repos = team.get_repos()
@@ -73,9 +77,9 @@ Use ``pip install py-allspice`` to install.
 
 ## Tests
 
-Tests can be run with: 
+Tests can be run with:
 
 ```python3 -m pytest test_api.py```
 
-Make sure to have a allspice-instance running on `http://localhost:3000`, and an admin-user token at `.token`. 
+Make sure to have an instance of AllSpice Hub running on `http://localhost:3000`, and an admin-user token at `.token`.
 The admin user must be named ``test``, with email ``secondarytest@test.org``.

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 from .gitea import (
-    Gitea,
+    AllSpice,
     User,
     Organization,
     Team,

--- a/allspice/__init__.py
+++ b/allspice/__init__.py
@@ -1,5 +1,5 @@
-from .gitea import (
-    Gitea,
+from .allspice import (
+    AllSpice,
     NotFoundException,
     AlreadyExistsException,
 )
@@ -19,7 +19,7 @@ from .apiobject import (
 )
 
 __all__ = [
-    'Gitea',
+    'AllSpice',
     'User',
     'Organization',
     'Team',

--- a/allspice/exceptions.py
+++ b/allspice/exceptions.py
@@ -20,9 +20,9 @@ class RawRequestEndpointMissing(Exception):
     pass
 
 
-class MissiongEqualyImplementation(Exception):
+class MissingEqualityImplementation(Exception):
     """
-    Each Object obtained from the gitea api must be able to check itself for equality in relation to its
+    Each Object obtained from the AllSpice Hub api must be able to check itself for equality in relation to its
     fields obtained from gitea. Risen if an api object is lacking the proper implementation.
     """
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-"""Fixtures for testing py-gitea
+"""Fixtures for testing py-allspice
 
 Instructions
 ------------
-put a ".token" file into your directory containg only the token for gitea
+put a ".token" file into your directory containg only the token for AllSpice Hub
 
 """
 
@@ -11,26 +11,26 @@ import os
 
 import pytest
 
-from gitea import Gitea
+from allspice import AllSpice
 
 @pytest.fixture
 def instance(scope="module"):
     try:
-        url = os.getenv("PY_GITEA_URL")
-        token = os.getenv("PY_GITEA_TOKEN")
-        auth = os.getenv("PY_GITEA_AUTH")
+        url = os.getenv("PY_ALLSPICE_URL")
+        token = os.getenv("PY_ALLSPICE_TOKEN")
+        auth = os.getenv("PY_ALLSPICE_AUTH")
         if not url:
-            raise ValueError("No Gitea URL was provided")
+            raise ValueError("No AllSpice Hub URL was provided")
         if token and auth:
             raise ValueError("Please provide auth or token_text, but not both")
-        g = Gitea(url, token_text=token, auth=auth, verify=False)
-        print("Gitea Version: " + g.get_version())
+        g = AllSpice(allspice_hub_url=url, token_text=token, auth=auth, verify=False)
+        print("AllSpice Hub Version: " + g.get_version())
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except:
         assert (
             False
-        ), "Gitea could not load. \
+        ), "AllSpice Hub could not load. \
                 - Instance running at http://localhost:3000 \
                 - Token at .token   \
                     ?"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,21 +3,21 @@ import base64
 import pytest
 import uuid
 
-from gitea import Gitea, User, Organization, Team, Repository, Issue, Milestone
-from gitea import NotFoundException, AlreadyExistsException
+from allspice import AllSpice, User, Organization, Team, Repository, Issue, Milestone
+from allspice import NotFoundException, AlreadyExistsException
 
-# put a ".token" file into your directory containg only the token for gitea
+# put a ".token" file into your directory containg only the token for AllSpice Hub
 @pytest.fixture
 def instance(scope="module"):
     try:
-        g = Gitea("http://localhost:3000", open(".token", "r").read().strip())
-        print("Gitea Version: " + g.get_version())
+        g = AllSpice("http://localhost:3000", open(".token", "r").read().strip())
+        print("AllSpice Hub Version: " + g.get_version())
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except:
         assert (
             False
-        ), "Gitea could not load. \
+        ), "AllSpice Hub could not load. \
                 - Instance running at http://localhost:3000 \
                 - Token at .token   \
                     ?"
@@ -35,7 +35,7 @@ def test_token_owner(instance):
     assert user.is_admin, "Testuser is not Admin - Tests may fail"
 
 
-def test_gitea_version(instance):
+def test_allspice_hub_version(instance):
     assert instance.get_version().startswith("1."), "No Version String returned"
 
 

--- a/tests/test_api_longtests.py
+++ b/tests/test_api_longtests.py
@@ -1,21 +1,21 @@
 import pytest
 import uuid
 
-from gitea import Gitea, User, Organization, Team, Repository, Issue
-from gitea import NotFoundException, AlreadyExistsException
+from allspice import AllSpice, User, Organization, Team, Repository, Issue
+from allspice import NotFoundException, AlreadyExistsException
 
-# put a ".token" file into your directory containg only the token for gitea
+# put a ".token" file into your directory containg only the token for AllSpice Hub
 @pytest.fixture
 def instance(scope="module"):
     try:
-        g = Gitea("http://localhost:3000", open(".token", "r").read().strip())
-        print("Gitea Version: " + g.get_version())
+        g = AllSpice("http://localhost:3000", open(".token", "r").read().strip())
+        print("AllSpice Hub Version: " + g.get_version())
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except:
         assert (
             False
-        ), "Gitea could not load. \
+        ), "AllSpice Hub could not load. \
                 - Instance running at http://localhost:3000 \
                 - Token at .token   \
                     ?"


### PR DESCRIPTION
Rename Gitea in all places where a user of the API would interact with AllSpice. Closes #1. 

A couple of notes:

1. I called the url `allspice_hub_url` instead of `allspice_url`,
2. Instead of calling the instance `allspice` I called it `allspice_client`,
3. In places where the code is talking about gitea I left it as is. 

These are not set in stone - if any of these seem like they're likely to cause confusion I can change that too.

