### PR TITLE
Add client functions for AllSpice-generated objects and an example BOM Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Forked from https://github.com/Langenfeld/py-gitea.
 
 ## Usage
 
+### Examples
+
+Check the [examples directory](./examples/) for full, working example scripts
+that you can adapt or refer to for your own needs.
+
+### Quickstart
+
 First get an `allspice_client` object wrapping access and authentication (via an api token) for your instance of AllSpice Hub.
 
 ```python

--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -55,6 +55,7 @@ class AllSpice:
         if token_text:
             self.headers["Authorization"] = "token " + token_text
         if auth:
+            self.logger.warning("Using basic auth is not recommended. Prefer using a token instead.")
             self.requests.auth = auth
 
         # Manage SSL certification verification

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -402,7 +402,7 @@ class Repository(ApiObject):
     def get_branch(self, name: str) -> 'Branch':
         """Get a specific Branch of this Repository."""
         result = self.allspice_client.requests_get(
-            Repository.REPO_BRANCH.format(owner=self.owner.username, name=self.name, branch=name)
+            Repository.REPO_BRANCH.format(owner=self.owner.username, repo=self.name, branch=name)
         )
         return Branch.parse_response(self.allspice_client, result)
 
@@ -917,6 +917,13 @@ class Util:
 
     @staticmethod
     def data_params_for_ref(ref: Optional[Ref]) -> Dict:
+        """
+        Given a "ref", returns a dict with the ref parameter for the API call.
+
+        If the ref is None, returns an empty dict. You can pass this to the API
+        directly.
+        """
+
         if isinstance(ref, Branch):
             return {"ref": ref.name}
         elif isinstance(ref, Commit):

--- a/allspice/exceptions.py
+++ b/allspice/exceptions.py
@@ -13,6 +13,15 @@ class ObjectIsInvalid(Exception):
 class ConflictException(Exception):
     pass
 
+class NotYetGeneratedException(Exception):
+    """
+    For AllSpice generated objects, this exception is raised when the
+    object has not yet been generated.
+
+    Usually, retrying after a while will be successful.
+    """
+    pass
+
 
 class RawRequestEndpointMissing(Exception):
     """This ApiObject can only be obtained through other api objects and does not have

--- a/examples/generate_bom/README.md
+++ b/examples/generate_bom/README.md
@@ -16,6 +16,7 @@ usage: generate_bom [-h] [--schdoc_repo SCHDOC_REPO]
                     [--schdoc_branch SCHDOC_BRANCH]
                     [--allspice_hub_url ALLSPICE_HUB_URL]
                     [--output_file OUTPUT_FILE]
+                    [--attributes_to_extract ATTRIBUTES_TO_EXTRACT]
                     source_repo source_file
 
 Generate a BOM from a PrjPcb file.
@@ -34,13 +35,15 @@ options:
                         main.
   --schdoc_branch SCHDOC_BRANCH
                         The branch containing the SchDoc files. Defaults to
-                        main.
+                        the same branch as PrjPcb.
   --allspice_hub_url ALLSPICE_HUB_URL
                         The URL of your AllSpice Hub instance. Defaults to
                         https://hub.allspice.io.
   --output_file OUTPUT_FILE
                         The path to the output file. If absent, the CSV will
                         be output to the command line.
+  --attributes_to_extract ATTRIBUTES_TO_EXTRACT
+                        A comma-seperated list of attributes to extract.
 ```
 
 Some examples of how you could run this are:
@@ -51,6 +54,8 @@ export ALLSPICE_AUTH_TOKEN= # some token
 python3 generate_bom.py "test/test" "test.PrjPcb" # Note that the options are not required!
 
 python3 generate_bom.py "test/test" "test.PrjPcb" --schdoc_repo "test/test_schdoc" --allspice_hub_url "https://my.selfhosted.example.org" --output_file bom.csv
+
+python3 generate_bom.py "test/test" "test.PrjPcb" --attribute_list "Designator,Manufacturer" # Will only extract these two attributes
 ```
 
 You can also import this python file in another file to use the methods defined

--- a/examples/generate_bom/README.md
+++ b/examples/generate_bom/README.md
@@ -1,0 +1,58 @@
+# Example: Generate a BOM from a PrjDoc file
+
+This script example shows you how you can use the AllSpice client to generate
+a BOM from a PrjDoc file. To use the script, start by running:
+
+```bash
+python3 generate_bom.py -h
+```
+
+As of writing, this generates the following help text:
+
+
+```
+usage: generate_bom [-h] [--schdoc_repo SCHDOC_REPO]
+                    [--source_branch SOURCE_BRANCH]
+                    [--schdoc_branch SCHDOC_BRANCH]
+                    [--allspice_hub_url ALLSPICE_HUB_URL]
+                    [--output_file OUTPUT_FILE]
+                    source_repo source_file
+
+Generate a BOM from a PrjPcb file.
+
+positional arguments:
+  source_repo           The repo containing the PrjPcb file.
+  source_file           The path to the PrjPcb file in the source repo.
+
+options:
+  -h, --help            show this help message and exit
+  --schdoc_repo SCHDOC_REPO
+                        The repo containing the SchDoc files. Defaults to the
+                        same repo as the PrjPcb file.
+  --source_branch SOURCE_BRANCH
+                        The branch containing the PrjPcb file. Defaults to
+                        main.
+  --schdoc_branch SCHDOC_BRANCH
+                        The branch containing the SchDoc files. Defaults to
+                        main.
+  --allspice_hub_url ALLSPICE_HUB_URL
+                        The URL of your AllSpice Hub instance. Defaults to
+                        https://hub.allspice.io.
+  --output_file OUTPUT_FILE
+                        The path to the output file. If absent, the CSV will
+                        be output to the command line.
+```
+
+Some examples of how you could run this are:
+
+```bash
+export ALLSPICE_AUTH_TOKEN= # some token
+
+python3 generate_bom.py "test/test" "test.PrjPcb" # Note that the options are not required!
+
+python3 generate_bom.py "test/test" "test.PrjPcb" --schdoc_repo "test/test_schdoc" --allspice_hub_url "https://my.selfhosted.example.org" --output_file bom.csv
+```
+
+You can also import this python file in another file to use the methods defined
+in it. If you want the BOM in a different format, or have other requirements,
+you can read and adapt this code, or use it as a reference for your own code.

--- a/examples/generate_bom/generate_bom.py
+++ b/examples/generate_bom/generate_bom.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python3
+
+# Generate a BOM from a PrjPcb file.
+# For more information, read the README file in this directory.
+
+import argparse
+import csv
+import os
+import re
+import sys
+
+from allspice import AllSpice
+
+
+def get_file_content(repo, file_path, branch):
+    """
+    Get the content of a file in a repo on a branch.
+    """
+
+    files_in_repo = repo.get_git_content(ref=branch)
+    file = next((x for x in files_in_repo if x.path == file_path), None)
+    if not file:
+        raise ValueError(
+            f"File {file_path} not found in repo {repo.name} on branch {branch.name}"
+        )
+
+    return repo.get_file_content(file, ref=branch)
+
+
+def get_schdoc_list_from_prjpcb(prjpcb_file_content):
+    """
+    Get a list of SchDoc files from a PrjPcb file.
+    """
+
+    pattern = re.compile(r"DocumentPath=(.*?SchDoc)\r\n")
+    return [match.group(1) for match in pattern.finditer(prjpcb_file_content)]
+
+
+def extract_attributes_from_schdoc(schdoc_file_content):
+    """
+    Extract the attributes from a schdoc file. You can edit this function to get
+    the attributes you want from the SchDoc file. To see what attributes are
+    available, print the schdoc_file_content variable.
+    """
+
+    attributes_list = []
+
+    for value in schdoc_file_content.values():
+        attributes = value["attributes"]
+
+        attributes_list.push(
+            [
+                attributes.get("Designator", {}).get("text"),
+                attributes.get("MANUFACTURER", {}).get("text"),
+                attributes.get("MANUFACTURER #", {}).get("text"),
+            ]
+        )
+
+    return attributes_list
+
+
+if __name__ == "__main__":
+    # Parse command line arguments. If you're writing a special purpose script,
+    # you can hardcode these values instead of using command line arguments.
+    parser = argparse.ArgumentParser(
+        prog="generate_bom", description="Generate a BOM from a PrjPcb file."
+    )
+    parser.add_argument("source_repo", help="The repo containing the PrjPcb file.")
+    parser.add_argument(
+        "source_file", help="The path to the PrjPcb file in the source repo."
+    )
+    parser.add_argument(
+        "--schdoc_repo",
+        help="The repo containing the SchDoc files. Defaults to the same repo as the PrjPcb file.",
+    )
+    parser.add_argument(
+        "--source_branch",
+        help="The branch containing the PrjPcb file. Defaults to main.",
+        default="main",
+    )
+    parser.add_argument(
+        "--schdoc_branch",
+        help="The branch containing the SchDoc files. Defaults to main.",
+        default="main",
+    )
+    parser.add_argument(
+        "--allspice_hub_url",
+        help="The URL of your AllSpice Hub instance. Defaults to https://hub.allspice.io.",
+    )
+    parser.add_argument(
+        "--output_file",
+        help="The path to the output file. If absent, the CSV will be output to the command line.",
+        default=None,
+    )
+
+    args = parser.parse_args()
+
+    # Use Environment Variables to store your auth token. This keeps your token
+    # secure when sharing code.
+    auth_token = os.environ.get("ALLSPICE_AUTH_TOKEN")
+    if auth_token is None:
+        print("Please set the environment variable ALLSPICE_AUTH_TOKEN")
+        exit(1)
+
+    if args.allspice_hub_url is None:
+        allspice = AllSpice(token_text=auth_token)
+    else:
+        allspice = AllSpice(
+            token_text=auth_token, allspice_hub_url=args.allspice_hub_url
+        )
+
+    source_repo = args.source_repo
+    source_file = args.source_file
+    schdoc_repo = args.schdoc_repo if args.schdoc_repo is not None else source_repo
+    source_branch = args.source_branch
+    schdoc_branch = args.schdoc_branch
+
+    # Get the PrjPcb file from the source repo.
+    prjpcb_repo = allspice.get_repo(source_repo)
+    prjpcb_branch = prjpcb_repo.get_branch(source_branch)
+    prjpcb_file = get_file_content(prjpcb_repo, source_file, prjpcb_branch)
+    schdoc_files_in_proj = {x for x in get_schdoc_list_from_prjpcb(prjpcb_file)}
+
+    # Get the SchDoc files from the SchDoc repo.
+    schdoc_repo = allspice.get_repo(schdoc_repo)
+    schdoc_branch = schdoc_repo.get_branch(schdoc_branch)
+    schdoc_files_in_repo = schdoc_repo.get_git_content(ref=schdoc_branch)
+
+    bom_rows = []
+
+    for schdoc_file in schdoc_files_in_repo:
+        if schdoc_file.path in schdoc_files_in_proj:
+            schdoc_file_json = schdoc_repo.get_generated_json(
+                schdoc_file, ref=schdoc_branch
+            )
+            bom_rows.extend(extract_attributes_from_schdoc(schdoc_file_json))
+
+    if args.output_file is not None:
+        f = open(args.output_file, "w")
+        writer = csv.writer(f)
+    else:
+        writer = csv.writer(sys.stdout)
+
+    # If you're extracting more or fewer attributes, you can change the header
+    # row here.
+    writer.writerow(["Designator", "Manufacturer", "Manufacturer Part Number"])
+    writer.writerows(bom_rows)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -133,6 +133,10 @@ def test_get_repository(instance):
     assert repo.name == test_repo
     assert repo.owner.username == test_org
 
+def test_get_repository_non_existent(instance):
+    with pytest.raises(NotFoundException) as e:
+        instance.get_repository("doesnotexist", "doesnotexist")
+
 
 def test_patch_repo(instance):
     fields = {
@@ -158,6 +162,20 @@ def test_list_branches(instance):
     assert len(branches) > 0
     master = [b for b in branches if b.name == "master"]
     assert len(master) > 0
+
+
+def test_get_branch(instance):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    branch = repo.get_branch("master")
+    assert branch is not None
+    assert branch.name == "master"
+
+def test_get_branch_non_existent(instance):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    with pytest.raises(NotFoundException) as e:
+        repo.get_branch("doesnotexist")
 
 def test_list_files_and_content(instance):
     org = Organization.request(instance, test_org)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,6 +127,12 @@ def test_create_repo_orgowned(instance):
     assert repo.name == test_repo
     assert not repo.private
 
+def test_get_repository(instance):
+    repo = instance.get_repository(test_org, test_repo)
+    assert repo is not None
+    assert repo.name == test_repo
+    assert repo.owner.username == test_org
+
 
 def test_patch_repo(instance):
     fields = {
@@ -386,3 +392,18 @@ def test_delete_user(instance):
     user.delete()
     with pytest.raises(NotFoundException) as e:
         User.request(instance, user_name)
+
+def test_get_generated_json(instance):
+    # Note: this expects the test repo to have a file called test.pcbdoc,
+    # which will have json and svg generated from it.
+    repo = instance.get_repository("test", "test")
+    json = repo.get_generated_json("test.pcbdoc")
+    assert json is not None
+    assert json["type"] == "Pcb"
+
+
+def test_get_generated_svg(instance):
+    repo = instance.get_repository("test", "test")
+    svg = repo.get_generated_svg("test.pcbdoc")
+    assert svg is not None
+    assert svg.startswith(b"<svg")


### PR DESCRIPTION
Adds:

1. Functions for fetching objects generated by AllSpice, i.e. the JSON and SVG files for cad files. 
2. An example script for generating a BOM from a PrjPcb file 
3. A few convenience methods in the client that made it much easier to work with in scripts like the BOM script. 

Instead of writing a complete method for generating the BOM as we considered for #8, I think this approach works out better because the specific needs for generating a BOM could differ from client to client.

Closes #14. Also closes #8 (@danielallspice lmk if you think there's something else we can do here for #8!)