### PR TITLE
Create example for team management with py-allspice

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .gitea import (
+from .allspice import (
     AllSpice,
     User,
     Organization,

--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -357,6 +357,7 @@ class AllSpice:
                     "repo.releases",
                     "repo.ext_wiki",
             ),
+            units_map={},
     ):
         """ Creates a Team.
 
@@ -365,7 +366,12 @@ class AllSpice:
             name (str): The Name of the Team to be created.
             description (str): Optional, None, short description of the new Team.
             permission (str): Optional, 'read', What permissions the members
+            units_map (dict): Optional, {}, a mapping of units to their
+                permissions. If None or empty, the `permission` permission will
+                be applied to all units. Note: When both `units` and `units_map`
+                are given, `units_map` will be preferred.
         """
+
         result = self.requests_post(
             AllSpice.CREATE_TEAM % org.username,
             data={
@@ -375,8 +381,10 @@ class AllSpice:
                 "can_create_org_repo": can_create_org_repo,
                 "includes_all_repositories": includes_all_repositories,
                 "units": units,
+                "units_map": units_map,
             },
         )
+
         if "id" in result:
             self.logger.info("Successfully created Team %s" % result["name"])
         else:

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -118,6 +118,38 @@ class Organization(ApiObject):
                 return team
         raise NotFoundException("Team not existent in organization.")
 
+    def create_team(
+            self,
+            name: str,
+            description: str = "",
+            permission: str = "read",
+            can_create_org_repo: bool = False,
+            includes_all_repositories: bool = False,
+            units=(
+                    "repo.code",
+                    "repo.issues",
+                    "repo.ext_issues",
+                    "repo.wiki",
+                    "repo.pulls",
+                    "repo.releases",
+                    "repo.ext_wiki",
+            ),
+            units_map={},
+    ) -> "Team":
+        """Alias for AllSpice#create_team"""
+        # TODO: Move AllSpice#create_team to Organization#create_team and
+        #       deprecate AllSpice#create_team.
+        return self.allspice_client.create_team(
+            org=self,
+            name=name,
+            description=description,
+            permission=permission,
+            can_create_org_repo=can_create_org_repo,
+            includes_all_repositories=includes_all_repositories,
+            units=units,
+            units_map=units_map,
+        )
+
     def get_members(self) -> List["User"]:
         results = self.allspice_client.requests_get(Organization.ORG_GET_MEMBERS % self.username)
         return [User.parse_response(self.allspice_client, result) for result in results]

--- a/examples/team_management/README.md
+++ b/examples/team_management/README.md
@@ -1,0 +1,9 @@
+# Example: Manage Teams
+
+This is a simple example script that showcases how you can manage your teams
+on AllSpice Hub with py-allspice. You shouldn't run this script directly, as it
+will certainly do things you don't want with your orgs and teams. Instead, use
+it as a reference when working on scripts that involve team management.
+
+This script is presented as a
+[Jupyter Notebook at manage_teams.ipynb](./manage_teams.ipynb)

--- a/examples/team_management/manage_teams.ipynb
+++ b/examples/team_management/manage_teams.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "# Imports\n",
     "\n",
-    "from allspice import AllSpice"
+    "from allspice import AllSpice, Organization"
    ]
   },
   {
@@ -53,7 +53,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Currently, you can only get all orgs at once, so index from the list.\n",
+    "# Get an organization by name\n",
+    "org = Organization.request(allspice_client, \"My Org\")\n",
+    "\n",
+    "# Or, get an organization from a list of all orgs\n",
     "org = allspice_client.get_orgs()[0]\n",
     "\n",
     "print(org)"
@@ -116,8 +119,8 @@
     "\n",
     "# or\n",
     "\n",
-    "# my_team = org.get_team(\"My Team\")\n",
-    "# print(my_team)"
+    "my_team = org.get_team(\"My-Team\")\n",
+    "print(my_team)"
    ]
   },
   {
@@ -227,7 +230,7 @@
     "\n",
     "# Get all teams in an org\n",
     "teams = org.get_teams()\n",
-    "print(f\"Org {org.name} has {len(teams)} teams\")"
+    "print(f\"Org {org.name} has {len(teams)} teams\")\n"
    ]
   }
  ],

--- a/examples/team_management/manage_teams.ipynb
+++ b/examples/team_management/manage_teams.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a simple example script that showcases how you can manage your teams\n",
+    "on AllSpice Hub with py-allspice. You shouldn't run this script directly, as it\n",
+    "will certainly do things you don't want with your orgs and teams. Instead, use\n",
+    "it as a reference when working on scripts that involve team management."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "\n",
+    "from allspice import AllSpice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the client\n",
+    "\n",
+    "# Never hard code a token in your code! Use something like\n",
+    "# os.environ.get(\"ALLSPICE_TOKEN\") instead.\n",
+    "allspice_client = AllSpice(token_text=\"<your token here>\")\n",
+    "\n",
+    "print(allspice_client.get_user())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating and Getting Teams\n",
+    "\n",
+    "Teams belong to an organisation, so we have to start with getting one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Currently, you can only get all orgs at once, so index from the list.\n",
+    "org = allspice_client.get_orgs()[0]\n",
+    "\n",
+    "print(org)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_team = allspice_client.create_team(\n",
+    "    org=org,\n",
+    "    # Team names can only contain alphanumeric characters, dashes and dots.\n",
+    "    name=\"My-New-Team\",\n",
+    "    description=\"This is my team\",\n",
+    "    permission=\"read\",\n",
+    "    can_create_org_repo=False,\n",
+    "    includes_all_repositories=True,\n",
+    "    # Either\n",
+    "    units=(\n",
+    "        \"repo.code\",\n",
+    "        \"repo.issues\",\n",
+    "        \"repo.ext_issues\",\n",
+    "        \"repo.wiki\",\n",
+    "    ),\n",
+    "    # Or\n",
+    "    units_map={\n",
+    "        \"repo.code\": \"read\",\n",
+    "        \"repo.issues\": \"write\",\n",
+    "        \"repo.ext_issues\": \"admin\",\n",
+    "        \"repo.wiki\": \"none\",\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "print(my_team.id)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that you should use either `units` or `units_map` - if you call\n",
+    "`create_team` with both, `units_map` will take precedence.\n",
+    "\n",
+    "You can also get teams from an org:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_teams = org.get_teams()\n",
+    "print(f\"There are {len(all_teams)} teams in this org.\")\n",
+    "my_team = all_teams[0]\n",
+    "print(my_team.name)\n",
+    "\n",
+    "# or\n",
+    "\n",
+    "# my_team = org.get_team(\"My Team\")\n",
+    "# print(my_team)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All of these methods return a `Team` object, which includes the properties of a\n",
+    "team:\n",
+    "\n",
+    "```\n",
+    "can_create_org_repo\n",
+    "description\n",
+    "id\n",
+    "includes_all_repositories\n",
+    "name\n",
+    "organization\n",
+    "permission\n",
+    "units\n",
+    "units_map\n",
+    "```\n",
+    "\n",
+    "This list of properties may be out of date - for the latest information, you can\n",
+    "check http://hub.allspice.io/api/swagger#/organization/orgCreateTeam."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Editing Teams\n",
+    "\n",
+    "If you want to edit a team, simply set its properties and call `commit()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_team.name = \"My-New-Team-Name\"\n",
+    "my_team.description = \"This is my new team description\"\n",
+    "my_team.commit()\n",
+    "\n",
+    "# Refetch the team to ensure the change went through\n",
+    "my_team = org.get_teams()[0]\n",
+    "print(my_team.name)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Managing Members\n",
+    "\n",
+    "You can see the members of a team with `get_members`, add a member with\n",
+    "`add_user` and remove a member with `remove_team_member`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get members\n",
+    "\n",
+    "members = my_team.get_members()\n",
+    "# This is a list of User objects.\n",
+    "print(f\"Team {my_team.name} has {len(members)} members\")\n",
+    "first_member = members[0]\n",
+    "print(f\"{first_member.username=}\")\n",
+    "\n",
+    "# Remove a member\n",
+    "# This takes a username, not a User object.\n",
+    "my_team.remove_team_member(first_member.username)\n",
+    "\n",
+    "new_members = my_team.get_members()\n",
+    "print(f\"Team {my_team.name} has {len(new_members)} members\")\n",
+    "\n",
+    "# Add a member\n",
+    "my_team.add_user(first_member)\n",
+    "new_members = my_team.get_members()\n",
+    "print(f\"Team {my_team.name} has {len(new_members)} members\")\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deleting teams\n",
+    "\n",
+    "Finally, deleting a team is as simple as calling delete() on it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_team.delete()\n",
+    "\n",
+    "# Get all teams in an org\n",
+    "teams = org.get_teams()\n",
+    "print(f\"Org {org.name} has {len(teams)} teams\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -238,6 +238,24 @@ def test_create_team(instance):
     assert team.description == "descr"
     assert team.organization == org
 
+def test_create_team_without_units_map(instance):
+    org = Organization.request(instance, test_org)
+    team = instance.create_team(org, test_team + "1", "descr")
+    permission = team.permission
+    assert set(team.units_map.keys()) == set(team.units)
+    assert list(team.units_map.values()) == [permission] * len(team.units)
+
+def test_create_team_with_units_map(instance):
+    org = Organization.request(instance, test_org)
+    team = instance.create_team(
+        org,
+        test_team + "2",
+        "descr",
+        units_map = {"repo.code": "write", "repo.wiki": "admin"}
+    )
+    assert set(team.units) == set(["repo.code", "repo.wiki"])
+    assert team.units_map == {"repo.code": "write", "repo.wiki": "admin"}
+
 def test_patch_team(instance):
     fields = {
         "can_create_org_repo": True,


### PR DESCRIPTION
Closes #7. This adds an example for managing teams with py-allspice in a Jupyter notebook format, along with a couple of small changes in team management for convenience.