### PR TITLE
Multiple small fixes and improvements

### DIFF
--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -426,7 +426,8 @@ class Repository(ApiObject):
 
     def get_branches(self) -> List['Branch']:
         """Get all the Branches of this Repository."""
-        results = self.allspice_client.requests_get(
+
+        results = self.allspice_client.requests_get_paginated(
             Repository.REPO_BRANCHES % (self.owner.username, self.name)
         )
         return [Branch.parse_response(self.allspice_client, result) for result in results]
@@ -507,7 +508,9 @@ class Repository(ApiObject):
         issues = []
         for result in results:
             issue = Issue.parse_response(self.allspice_client, result)
-            Issue._add_read_property("repository", self, issue)
+            # This is mostly for compatibility with the older implementation, as the
+            # `repository` property already has this info in the parsed Issue.
+            Issue._add_read_property("repo", self, issue)
             Issue._add_read_property("owner", self.owner, issue)
             issues.append(issue)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -464,8 +464,8 @@ def test_create_design_review(instance):
 
     assert review.state == DesignReview.OPEN
     assert review.title == "TestDesignReview"
-    assert review.base.name == "master"
-    assert review.head.name == "test_branch"
+    assert review.base == "master"
+    assert review.head == "test_branch"
     assert review.body == "This is a test review"
     assert review.assignees[0].username == "test"
     assert Util.format_time(Util.convert_time(review.due_date)) == Util.format_time(
@@ -478,8 +478,8 @@ def test_get_design_reviews(instance):
     dr = repo.get_design_reviews()[0]
 
     assert dr.title == "TestDesignReview"
-    assert dr.base.name == "master"
-    assert dr.head.name == "test_branch"
+    assert dr.base == "master"
+    assert dr.head == "test_branch"
     assert dr.body == "This is a test review"
 
 
@@ -496,8 +496,8 @@ def test_edit_design_review(instance):
     del dr
     dr = repo.get_design_reviews()[0]
     assert dr.title == "TestDesignReview2"
-    assert dr.base.name == "test_branch2"
-    assert dr.head.name == "test_branch"
+    assert dr.base == "test_branch2"
+    assert dr.head == "test_branch"
     assert dr.body == "This is a test review2"
     assert dr.due_date is None
 


### PR DESCRIPTION
Sorry for the kitchen sink PR - this includes:

1. Filtering options for issues, design reviews and commits
2. A refactor of the `commit` method for the API Objects which fixes committing multiple times in a repo sending excess data.
3. `get_branches` fetches all branches in a repo instead of just the first page.
4. Using strings for the `base` and `head` fields of Design Reviews, which fixes an issue when a design review is against/from a deleted branch, as can happen after a DR is closed.