### PR TITLE
Fix links in the example README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,13 @@
 # py-allspice Usage Examples
 
-This directory contains examples which show how to use py-allspice. The examples may be 
-presented as Jupyter notebooks, Python scripts, or both. The Jupyter notebooks are 
+This directory contains examples which show how to use py-allspice. The examples may be
+presented as Jupyter notebooks, Python scripts, or both. The Jupyter notebooks are
 intended to be "guided tours" through common functionality, while the Python scripts
 are intended to be more "plug and play" examples that you can use as a reference or even
 directly in your projects.
 
-In either case, you should always be careful about running code that you don't understand 
-on any repository that you care about. Make sure you fully understand what the code is 
+In either case, you should always be careful about running code that you don't understand
+on any repository that you care about. Make sure you fully understand what the code is
 doing, and make any changes to suit your circumstances or use case before running them.
 
 ## Index
@@ -17,4 +17,4 @@ doing, and make any changes to suit your circumstances or use case before runnin
 - [Example: Working with DRs](./working_with_drs)
 - [Example: Backing up a Repository](./backup_repo)
 - [Example: Generate a BOM from a PrjPcb file](./generate_bom)
-- [Example: Check if a Part is in a Schematic Library](./check_parts_in_libraries)
+- [Example: Check if a Part is in a Repository](./check_parts_in_schematics)

--- a/examples/check_parts_in_schematics/README.md
+++ b/examples/check_parts_in_schematics/README.md
@@ -1,17 +1,18 @@
-# Example: Check if a Part is in a Schematic Library
+# Example: Check if a Part is in a Repository
 
 This is an advanced example that checks every branch of a repository to see if:
 
 1. It has a Schematic Document called "Main.SchDoc"
 2. That Schematic Document contains a part with a given name
 
-You can change the name of the SchDoc file it looks for via CLI args. This
-example only works with py-allspice v2.0.0 and above.
+You can change the name of the SchDoc file it looks for via CLI args, and check
+all Schematic Documents in a repo too. This example only works with py-allspice
+v2.0.0 and above.
 
 One use case here could be to see if a repository is using a part that has since been
 deprecated, or to find out which repositories are using a part that you want to update.
 
-The example is in [this python script](./check_parts_in_libraries.py). To get started,
+The example is in [this python script](./check_parts_in_schematics.py). To get started,
 run:
 
 ```bash


### PR DESCRIPTION
Sorry about this - didn't catch the typos until the release. I had to rename the script because I realized "Schematic Library" is a loaded term, but I forgot to make all the changes in readme and the index. This led to a few broken links which can be confusing.