### PR TITLE
Prep for v2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v2.3.0
+
+This is a minor version bump. Only new functionality was added, and you may not
+need to change your scripts to update to this version.
+
+- New feature: BOM Generation. Instead of an example script, BOM generation is
+  included as a util within the library. See `allspice.utils.generate_bom` for
+  more details, and there is an example script in
+  [the examples/generate_bom directory](./examples/generate_bom/) that shows how
+  to use it, along with how to compute COGS from a generated BOM.
+- `Team.add_repo` now takes either a string as a repo name or a `Repository`
+  object, instead of just a string as before. So you can:
+
+  ```py
+  team.add_repo(team_org, "repo_name")
+  ```
+
+  Instead of:
+
+  ```py
+  repo = Repository.request(allspice_client, "team_org", "repo_name")
+  team.add_repo(team_org, repo)
+  ```
+
+  This is useful if you are making a large number of changes in bulk, as you can
+  save time by not having to make a request for each repo you want to add to a
+  team.
+
 ## v2.2.0
 
 This is a minor version bump. Only new functionality was added, and you may not

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -411,7 +411,7 @@ class Repository(ApiObject):
 
     @classmethod
     def search(
-        cls, 
+        cls,
         allspice_client: 'AllSpice',
         query: Optional[str] = None,
         topic: bool = False,
@@ -422,12 +422,12 @@ class Repository(ApiObject):
         """
         Search for repositories.
 
-        See https://hub.allspice.io/api/swagger#/repository/repoSearch 
+        See https://hub.allspice.io/api/swagger#/repository/repoSearch
 
         :param query: The query string to search for
-        :param topic: If true, the query string will only be matched against the 
+        :param topic: If true, the query string will only be matched against the
             repository's topic.
-        :param include_description: If true, the query string will be matched 
+        :param include_description: If true, the query string will be matched
             against the repository's description as well.
         :param user: If specified, only repositories that this user owns or
             contributes to will be searched.
@@ -452,7 +452,7 @@ class Repository(ApiObject):
 
         responses = allspice_client.requests_get_paginated(cls.REPO_SEARCH, params=params)
 
-        return [Repository.parse_response(allspice_client, response) 
+        return [Repository.parse_response(allspice_client, response)
                 for response in responses]
 
 
@@ -975,7 +975,7 @@ class Repository(ApiObject):
         """
         Adds a topic to the repository.
 
-        See https://hub.allspice.io/api/swagger#/repository/repoAddTopic 
+        See https://hub.allspice.io/api/swagger#/repository/repoAddTopic
 
         :param topic: The topic to add. Topic names must consist only of
             lowercase letters, numnbers and dashes (-), and cannot start with
@@ -983,8 +983,8 @@ class Repository(ApiObject):
         """
 
         url = self.REPO_ADD_TOPIC.format(
-            owner=self.owner.username, 
-            repo=self.name, 
+            owner=self.owner.username,
+            repo=self.name,
             topic=topic
         )
         self.allspice_client.requests_put(url)
@@ -1548,8 +1548,12 @@ class Team(ApiObject):
         url = f"/teams/{self.id}/members/{user.login}"
         self.allspice_client.requests_put(url)
 
-    def add_repo(self, org: Organization, repo: Repository):
-        self.allspice_client.requests_put(Team.ADD_REPO % (self.id, org, repo.name))
+    def add_repo(self, org: Organization, repo: Union[Repository, str]):
+        if isinstance(repo, Repository):
+            repo_name = repo.name
+        else:
+            repo_name = repo
+        self.allspice_client.requests_put(Team.ADD_REPO % (self.id, org.username, repo_name))
 
     def get_members(self):
         """ Get all users assigned to the team. """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -323,6 +323,23 @@ def test_create_team(instance):
     assert team.description == "descr"
     assert team.organization == org
 
+def test_add_repo_to_team(instance):
+    org = Organization.request(instance, test_org)
+    team = org.get_team(test_team)
+    repository = Repository.request(instance, test_org, test_repo)
+
+    # First with name
+    team.add_repo(org, test_repo)
+    assert test_repo in [repo.name for repo in team.get_repos()]
+
+    team.delete()
+
+    team = instance.create_team(org, test_team, "descr")
+    # Then with object
+    team.add_repo(org, repository)
+    assert test_repo in [repo.name for repo in team.get_repos()]
+
+
 def test_create_team_without_units_map(instance):
     org = Organization.request(instance, test_org)
     team = instance.create_team(org, test_team + "1", "descr")


### PR DESCRIPTION
The major change for this release is BOM generation, but I'm also sneaking in a small change: `Team.add_repo` doesn't need an entire repo object, so we also take a string instead.

(Some whitespace changes snuck in because of my trim whitespace settings)