### PR TITLE
Get all team members from paginated responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.3.1
+
+This is a patch release. You should be able to update to this version without
+changing your scripts.
+
+- Fix a bug where `Team.get_members` would not return all members if there
+  were more than 30 members in a team.
+
 ## v2.3.0
 
 This is a minor version bump. Only new functionality was added, and you may not

--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -123,8 +123,15 @@ class AllSpice:
             combined_params["sudo"] = sudo.username
         return self.__get(endpoint, combined_params).content
 
-    def requests_get_paginated(self, endpoint: str, params=frozendict(), sudo=None, page_key: str = "page"):
-        page = 1
+    def requests_get_paginated(
+        self,
+        endpoint: str,
+        params=frozendict(),
+        sudo=None,
+        page_key: str = "page",
+        first_page: int = 1,
+    ):
+        page = first_page
         combined_params = {}
         combined_params.update(params)
         aggregated_result = []

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -1560,7 +1560,11 @@ class Team(ApiObject):
 
     def get_members(self):
         """ Get all users assigned to the team. """
-        results = self.allspice_client.requests_get(Team.GET_MEMBERS % self.id)
+        results = self.allspice_client.requests_get_paginated(
+            Team.GET_MEMBERS % self.id,
+            # The docs say this should start with 1 but the first page is 0.
+            first_page=0,
+        )
         return [User.parse_response(self.allspice_client, result) for result in results]
 
     def get_repos(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup_args = dict(
     author='AllSpice, Inc.',
     author_email='maintainers@allspice.io',
     keywords=['AllSpice', 'AllSpice Hub', 'api', 'wrapper'],
-    url='https://github.com/Langenfeld/py-gitea',
+    url='https://github.com/AllSpiceIO/py-allspice',
     download_url='https://github.com/AllSpiceIO/py-allspice'
 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,7 +71,7 @@ def test_create_user(instance):
     assert email in user.emails
     assert user.email == email
     assert not user.is_admin
-    assert type(user.id) is int
+    assert isinstance(user.id, int)
     assert user.is_admin is False
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -408,9 +408,18 @@ def test_user_teams(instance):
     org = Organization.request(instance, test_org)
     team = org.get_team(test_team)
     user = instance.get_user_by_name(test_user)
+
     team.add_user(user)
     teams = user.get_teams()
     assert team in teams
+    team_members = team.get_members()
+    assert user in team_members
+
+    team.remove_team_member(user.login)
+    teams = user.get_teams()
+    assert team not in teams
+    team_members = team.get_members()
+    assert user not in team_members
 
 
 def test_get_accessible_repositories(instance):
@@ -643,9 +652,8 @@ def test_get_repo_archive(instance):
 
 def test_team_get_org(instance):
     org = Organization.request(instance, test_org)
-    user = instance.get_user_by_name(test_user)
-    teams = user.get_teams()
-    assert org.username == teams[0].organization.name
+    team = org.get_team(test_team)
+    assert org.username == team.organization.name
 
 
 def test_delete_repo_userowned(instance):

--- a/tests/test_api_longtests.py
+++ b/tests/test_api_longtests.py
@@ -51,3 +51,21 @@ def test_list_issue(instance):
                            "We will be too many to be listed on one page")
     issues = repo.get_issues()
     assert len(issues) > 98
+
+
+def test_list_team_members(instance):
+    org = Organization.request(instance, test_org)
+    team = org.create_team(test_team, "Team for longtests")
+    users = []
+    for i in range(100):
+        users.append(
+            instance.create_user(
+                test_user + str(i),
+                test_user + str(i) + "@example.org",
+                "abcdefg1.23AB",
+                send_notify=False
+            ),
+        )
+    for user in users:
+        team.add_user(user)
+    assert len(team.get_members()) == len(users)


### PR DESCRIPTION
Fixes a reported issue where not all members of a team were being returned.