### PR TITLE
Broaden newline regex in Alitum BOM generation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # ruff: noqa: F401
 
-from .allspice import (
+from allspice import (
     AllSpice,
     User,
     Organization,

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -513,10 +513,16 @@ class Repository(ApiObject):
         )
         return Branch.parse_response(self.allspice_client, result)
 
-    def add_branch(self, create_from: Branch, newname: str) -> "Branch":
+    def add_branch(self, create_from: Ref, newname: str) -> "Branch":
         """Add a branch to the repository"""
         # Note: will only work with gitea 1.13 or higher!
-        data = {"new_branch_name": newname, "old_branch_name": create_from.name}
+
+        ref_name = Util.data_params_for_ref(create_from)
+        if "ref" not in ref_name:
+            raise ValueError("create_from must be a Branch, Commit or string")
+        ref_name = ref_name["ref"]
+
+        data = {"new_branch_name": newname, "old_ref_name": ref_name}
         result = self.allspice_client.requests_post(
             Repository.REPO_BRANCHES % (self.owner.username, self.name), data=data
         )

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -183,7 +183,9 @@ def _extract_schdoc_list_from_prjpcb(prjpcb_file_content) -> list[str]:
     Get a list of SchDoc files from a PrjPcb file.
     """
 
-    pattern = re.compile(r"DocumentPath=(.*?SchDoc)\r\n")
+    # Sometimes the SchDoc file can use \n\r instead of CRLF line endings. 
+    # Unfortunately, it looks like $ even with re.M doesn't(?) match \n\r.
+    pattern = re.compile(r"DocumentPath=(.*?SchDoc)(\r\n|\n\r|\n)")
     return [match.group(1) for match in pattern.finditer(prjpcb_file_content)]
 
 

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -12,6 +12,8 @@ from ..allspice import AllSpice
 from ..apiobject import Content, Ref, Repository
 from ..exceptions import NotYetGeneratedException
 
+PRJPCB_SCHDOC_REGEX = re.compile(r"DocumentPath=(.*?SchDoc)(\r\n|\n\r|\n)")
+
 
 @dataclass
 class SchematicComponent:
@@ -185,8 +187,7 @@ def _extract_schdoc_list_from_prjpcb(prjpcb_file_content) -> list[str]:
 
     # Sometimes the SchDoc file can use \n\r instead of CRLF line endings.
     # Unfortunately, it looks like $ even with re.M doesn't(?) match \n\r.
-    pattern = re.compile(r"DocumentPath=(.*?SchDoc)(\r\n|\n\r|\n)")
-    return [match.group(1) for match in pattern.finditer(prjpcb_file_content)]
+    return [match.group(1) for match in PRJPCB_SCHDOC_REGEX.finditer(prjpcb_file_content)]
 
 
 def _schdoc_component_from_attributes(

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -183,7 +183,7 @@ def _extract_schdoc_list_from_prjpcb(prjpcb_file_content) -> list[str]:
     Get a list of SchDoc files from a PrjPcb file.
     """
 
-    # Sometimes the SchDoc file can use \n\r instead of CRLF line endings. 
+    # Sometimes the SchDoc file can use \n\r instead of CRLF line endings.
     # Unfortunately, it looks like $ even with re.M doesn't(?) match \n\r.
     pattern = re.compile(r"DocumentPath=(.*?SchDoc)(\r\n|\n\r|\n)")
     return [match.group(1) for match in pattern.finditer(prjpcb_file_content)]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -348,6 +348,17 @@ def test_create_branch(instance):
     assert len(branches) == number_of_branches + 1
 
 
+def test_create_branch_from_str_ref(instance):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    branches = repo.get_branches()
+    number_of_branches = len(branches)
+    new_branch_name = "branch-" + uuid.uuid4().hex[:8]
+    repo.add_branch("master", new_branch_name)
+    branches = repo.get_branches()
+    assert len(branches) == number_of_branches + 1
+
+
 def test_create_team(instance):
     org = Organization.request(instance, test_org)
     team = instance.create_team(org, test_team, "descr")


### PR DESCRIPTION
Closes #60.

The `PrjPcb` can use `\n\r` for new lines instead of `\r\n`, which is what we expect. This PR changes the regex we use to support both (along with `\n`.) Additionally, while writing a test for this code, I updated a deprecated method to create branches.
