### PR TITLE
Remove autopep8 completely

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           pip install -r requirements-test.txt
       - name: Check formatting
         run: |
-          autopep8 --diff --recursive --exit-code .
+          ruff format --diff .
       - name: Lint with ruff
         run: |
           ruff --target-version=py310 .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "[python]": {
-        "editor.defaultFormatter": "ms-python.autopep8",
+        "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true
-      }
+    }
 }

--- a/allspice/__init__.py
+++ b/allspice/__init__.py
@@ -12,26 +12,23 @@ from .apiobject import (
     Commit,
     Comment,
     Content,
-    DesignReview
+    DesignReview,
 )
-from .exceptions import (
-    NotFoundException,
-    AlreadyExistsException
-)
+from .exceptions import NotFoundException, AlreadyExistsException
 
 __all__ = [
-    'AllSpice',
-    'User',
-    'Organization',
-    'Team',
-    'Repository',
-    'Branch',
-    'NotFoundException',
-    'AlreadyExistsException',
-    'Issue',
-    'Milestone',
-    'Commit',
-    'Comment',
-    'Content',
-    'DesignReview'
+    "AllSpice",
+    "User",
+    "Organization",
+    "Team",
+    "Repository",
+    "Branch",
+    "NotFoundException",
+    "AlreadyExistsException",
+    "Issue",
+    "Milestone",
+    "Commit",
+    "Comment",
+    "Content",
+    "DesignReview",
 ]

--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -7,7 +7,12 @@ import requests
 import urllib3
 
 from .apiobject import User, Organization, Repository, Team
-from .exceptions import NotFoundException, ConflictException, AlreadyExistsException, NotYetGeneratedException
+from .exceptions import (
+    NotFoundException,
+    ConflictException,
+    AlreadyExistsException,
+    NotYetGeneratedException,
+)
 from .ratelimiter import RateLimitedSession
 
 
@@ -73,7 +78,8 @@ class AllSpice:
             self.headers["Authorization"] = "token " + token_text
         if auth:
             self.logger.warning(
-                "Using basic auth is not recommended. Prefer using a token instead.")
+                "Using basic auth is not recommended. Prefer using a token instead."
+            )
             self.requests.auth = auth
 
         # Manage SSL certification verification
@@ -94,7 +100,8 @@ class AllSpice:
                 raise NotFoundException(message)
             if request.status_code in [403]:
                 raise Exception(
-                    f"Unauthorized: {request.url} - Check your permissions and try again! ({message})")
+                    f"Unauthorized: {request.url} - Check your permissions and try again! ({message})"
+                )
             if request.status_code in [409]:
                 raise ConflictException(message)
             if request.status_code in [503]:
@@ -104,7 +111,7 @@ class AllSpice:
 
     @staticmethod
     def parse_result(result) -> Dict:
-        """ Parses the result-JSON to a dict. """
+        """Parses the result-JSON to a dict."""
         if result.text and len(result.text) > 3:
             return json.loads(result.text)
         return {}
@@ -160,27 +167,29 @@ class AllSpice:
     def requests_put(self, endpoint: str, data: Optional[dict] = None):
         if not data:
             data = {}
-        request = self.requests.put(self.__get_url(
-            endpoint), headers=self.headers, data=json.dumps(data))
+        request = self.requests.put(
+            self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
+        )
         if request.status_code not in [200, 204]:
             message = f"Received status code: {request.status_code} ({request.url}) {request.text}"
             self.logger.error(message)
             raise Exception(message)
 
     def requests_delete(self, endpoint: str, data: Optional[dict] = None):
-        request = self.requests.delete(self.__get_url(
-            endpoint), headers=self.headers, data=json.dumps(data))
+        request = self.requests.delete(
+            self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
+        )
         if request.status_code not in [200, 204]:
             message = f"Received status code: {request.status_code} ({request.url})"
             self.logger.error(message)
             raise Exception(message)
 
     def requests_post(
-            self,
-            endpoint: str,
-            data: Optional[dict] = None,
-            params: Optional[dict] = None,
-            files: Optional[dict] = None,
+        self,
+        endpoint: str,
+        data: Optional[dict] = None,
+        params: Optional[dict] = None,
+        files: Optional[dict] = None,
     ):
         """
         Make a POST call to the endpoint.
@@ -207,19 +216,21 @@ class AllSpice:
         request = self.requests.post(self.__get_url(endpoint), **args)
 
         if request.status_code not in [200, 201, 202]:
-            if ("already exists" in request.text or "e-mail already in use" in request.text):
+            if "already exists" in request.text or "e-mail already in use" in request.text:
                 self.logger.warning(request.text)
                 raise AlreadyExistsException()
             self.logger.error(f"Received status code: {request.status_code} ({request.url})")
             self.logger.error(f"With info: {data} ({self.headers})")
             self.logger.error(f"Answer: {request.text}")
             raise Exception(
-                f"Received status code: {request.status_code} ({request.url}), {request.text}")
+                f"Received status code: {request.status_code} ({request.url}), {request.text}"
+            )
         return self.parse_result(request)
 
     def requests_patch(self, endpoint: str, data: dict):
-        request = self.requests.patch(self.__get_url(
-            endpoint), headers=self.headers, data=json.dumps(data))
+        request = self.requests.patch(
+            self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
+        )
         if request.status_code not in [200, 201]:
             error_message = f"Received status code: {request.status_code} ({request.url}) {data}"
             self.logger.error(error_message)
@@ -267,17 +278,17 @@ class AllSpice:
         return Repository.parse_response(self, result)
 
     def create_user(
-            self,
-            user_name: str,
-            email: str,
-            password: str,
-            full_name: Optional[str] = None,
-            login_name: Optional[str] = None,
-            change_pw=True,
-            send_notify=True,
-            source_id=0,
+        self,
+        user_name: str,
+        email: str,
+        password: str,
+        full_name: Optional[str] = None,
+        login_name: Optional[str] = None,
+        change_pw=True,
+        send_notify=True,
+        source_id=0,
     ):
-        """ Create User.
+        """Create User.
         Throws:
             AlreadyExistsException, if the User exists already
             Exception, if something else went wrong.
@@ -314,19 +325,19 @@ class AllSpice:
         return user
 
     def create_repo(
-            self,
-            repoOwner: Union[User, Organization],
-            repoName: str,
-            description: str = "",
-            private: bool = False,
-            autoInit=True,
-            gitignores: Optional[str] = None,
-            license: Optional[str] = None,
-            readme: str = "Default",
-            issue_labels: Optional[str] = None,
-            default_branch="master",
+        self,
+        repoOwner: Union[User, Organization],
+        repoName: str,
+        description: str = "",
+        private: bool = False,
+        autoInit=True,
+        gitignores: Optional[str] = None,
+        license: Optional[str] = None,
+        readme: str = "Default",
+        issue_labels: Optional[str] = None,
+        default_branch="master",
     ):
-        """ Create a Repository as the administrator
+        """Create a Repository as the administrator
 
         Throws:
             AlreadyExistsException: If the Repository exists already.
@@ -361,13 +372,13 @@ class AllSpice:
         return Repository.parse_response(self, result)
 
     def create_org(
-            self,
-            owner: User,
-            orgName: str,
-            description: str,
-            location="",
-            website="",
-            full_name="",
+        self,
+        owner: User,
+        orgName: str,
+        description: str,
+        location="",
+        website="",
+        full_name="",
     ):
         assert isinstance(owner, User)
         result = self.requests_post(
@@ -381,39 +392,33 @@ class AllSpice:
             },
         )
         if "id" in result:
-            self.logger.info(
-                "Successfully created Organization %s" % result["username"]
-            )
+            self.logger.info("Successfully created Organization %s" % result["username"])
         else:
-            self.logger.error(
-                "Organization not created... (gitea: %s)" % result["message"]
-            )
+            self.logger.error("Organization not created... (gitea: %s)" % result["message"])
             self.logger.error(result["message"])
-            raise Exception(
-                "Organization not created... (gitea: %s)" % result["message"]
-            )
+            raise Exception("Organization not created... (gitea: %s)" % result["message"])
         return Organization.parse_response(self, result)
 
     def create_team(
-            self,
-            org: Organization,
-            name: str,
-            description: str = "",
-            permission: str = "read",
-            can_create_org_repo: bool = False,
-            includes_all_repositories: bool = False,
-            units=(
-                "repo.code",
-                "repo.issues",
-                "repo.ext_issues",
-                "repo.wiki",
-                "repo.pulls",
-                "repo.releases",
-                "repo.ext_wiki",
-            ),
-            units_map={},
+        self,
+        org: Organization,
+        name: str,
+        description: str = "",
+        permission: str = "read",
+        can_create_org_repo: bool = False,
+        includes_all_repositories: bool = False,
+        units=(
+            "repo.code",
+            "repo.issues",
+            "repo.ext_issues",
+            "repo.wiki",
+            "repo.pulls",
+            "repo.releases",
+            "repo.ext_wiki",
+        ),
+        units_map={},
     ):
-        """ Creates a Team.
+        """Creates a Team.
 
         Args:
             org (Organization): Organization the Team will be part of.

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -33,11 +33,11 @@ class Organization(ApiObject):
         return hash(self.allspice_client) ^ hash(self.name)
 
     @classmethod
-    def request(cls, allspice_client, name: str) -> 'Organization':
+    def request(cls, allspice_client, name: str) -> "Organization":
         return cls._request(allspice_client, {"name": name})
 
     @classmethod
-    def parse_response(cls, allspice_client, result) -> 'Organization':
+    def parse_response(cls, allspice_client, result) -> "Organization":
         api_object = super().parse_response(allspice_client, result)
         # add "name" field to make this behave similar to users for gitea < 1.18
         # also necessary for repository-owner when org is repo owner
@@ -58,16 +58,16 @@ class Organization(ApiObject):
         self._commit(args)
 
     def create_repo(
-            self,
-            repoName: str,
-            description: str = "",
-            private: bool = False,
-            autoInit=True,
-            gitignores: Optional[str] = None,
-            license: Optional[str] = None,
-            readme: str = "Default",
-            issue_labels: Optional[str] = None,
-            default_branch="master",
+        self,
+        repoName: str,
+        description: str = "",
+        private: bool = False,
+        autoInit=True,
+        gitignores: Optional[str] = None,
+        license: Optional[str] = None,
+        readme: str = "Default",
+        issue_labels: Optional[str] = None,
+        default_branch="master",
     ):
         """Create an organization Repository
 
@@ -110,9 +110,7 @@ class Organization(ApiObject):
         raise NotFoundException("Repository %s not existent in organization." % name)
 
     def get_teams(self) -> List["Team"]:
-        results = self.allspice_client.requests_get(
-            Organization.ORG_TEAMS_REQUEST % self.username
-        )
+        results = self.allspice_client.requests_get(Organization.ORG_TEAMS_REQUEST % self.username)
         teams = [Team.parse_response(self.allspice_client, result) for result in results]
         # organisation seems to be missing using this request, so we add org manually
         for t in teams:
@@ -127,22 +125,22 @@ class Organization(ApiObject):
         raise NotFoundException("Team not existent in organization.")
 
     def create_team(
-            self,
-            name: str,
-            description: str = "",
-            permission: str = "read",
-            can_create_org_repo: bool = False,
-            includes_all_repositories: bool = False,
-            units=(
-                "repo.code",
-                "repo.issues",
-                "repo.ext_issues",
-                "repo.wiki",
-                "repo.pulls",
-                "repo.releases",
-                "repo.ext_wiki",
-            ),
-            units_map={},
+        self,
+        name: str,
+        description: str = "",
+        permission: str = "read",
+        can_create_org_repo: bool = False,
+        includes_all_repositories: bool = False,
+        units=(
+            "repo.code",
+            "repo.issues",
+            "repo.ext_issues",
+            "repo.wiki",
+            "repo.pulls",
+            "repo.releases",
+            "repo.ext_wiki",
+        ),
+        units_map={},
     ) -> "Team":
         """Alias for AllSpice#create_team"""
         # TODO: Move AllSpice#create_team to Organization#create_team and
@@ -179,7 +177,7 @@ class Organization(ApiObject):
         self.allspice_client.requests_delete(path)
 
     def delete(self):
-        """ Delete this Organization. Invalidates this Objects data. Also deletes all Repositories owned by the User"""
+        """Delete this Organization. Invalidates this Objects data. Also deletes all Repositories owned by the User"""
         for repo in self.get_repositories():
             repo.delete()
         self.allspice_client.requests_delete(Organization.API_OBJECT.format(name=self.username))
@@ -258,16 +256,16 @@ class User(ApiObject):
         self._dirty_fields = {}
 
     def create_repo(
-            self,
-            repoName: str,
-            description: str = "",
-            private: bool = False,
-            autoInit=True,
-            gitignores: Optional[str] = None,
-            license: Optional[str] = None,
-            readme: str = "Default",
-            issue_labels: Optional[str] = None,
-            default_branch="master",
+        self,
+        repoName: str,
+        description: str = "",
+        private: bool = False,
+        autoInit=True,
+        gitignores: Optional[str] = None,
+        license: Optional[str] = None,
+        readme: str = "Default",
+        issue_labels: Optional[str] = None,
+        default_branch="master",
     ):
         """Create a user Repository
 
@@ -297,24 +295,24 @@ class User(ApiObject):
         return Repository.parse_response(self, result)
 
     def get_repositories(self) -> List["Repository"]:
-        """ Get all Repositories owned by this User."""
+        """Get all Repositories owned by this User."""
         url = f"/users/{self.username}/repos"
         results = self.allspice_client.requests_get_paginated(url)
         return [Repository.parse_response(self.allspice_client, result) for result in results]
 
     def get_orgs(self) -> List[Organization]:
-        """ Get all Organizations this user is a member of."""
+        """Get all Organizations this user is a member of."""
         url = f"/users/{self.username}/orgs"
         results = self.allspice_client.requests_get_paginated(url)
         return [Organization.parse_response(self.allspice_client, result) for result in results]
 
-    def get_teams(self) -> List['Team']:
+    def get_teams(self) -> List["Team"]:
         url = "/user/teams"
         results = self.allspice_client.requests_get_paginated(url, sudo=self)
         return [Team.parse_response(self.allspice_client, result) for result in results]
 
-    def get_accessible_repos(self) -> List['Repository']:
-        """ Get all Repositories accessible by the logged in User."""
+    def get_accessible_repos(self) -> List["Repository"]:
+        """Get all Repositories accessible by the logged in User."""
         results = self.allspice_client.requests_get("/user/repos", sudo=self)
         return [Repository.parse_response(self, result) for result in results]
 
@@ -327,7 +325,7 @@ class User(ApiObject):
                 self._email = mail["email"]
 
     def delete(self):
-        """ Deletes this User. Also deletes all Repositories he owns."""
+        """Deletes this User. Also deletes all Repositories he owns."""
         self.allspice_client.requests_delete(User.ADMIN_DELETE_USER % self.username)
         self.deleted = True
 
@@ -406,16 +404,17 @@ class Repository(ApiObject):
     _fields_to_parsers: ClassVar[dict] = {
         # dont know how to tell apart user and org as owner except form email being empty.
         "owner": lambda allspice_client, r: Organization.parse_response(allspice_client, r)
-        if r["email"] == "" else User.parse_response(allspice_client, r),
+        if r["email"] == ""
+        else User.parse_response(allspice_client, r),
         "updated_at": lambda allspice_client, t: Util.convert_time(t),
     }
 
     @classmethod
     def request(
-            cls,
-            allspice_client,
-            owner: str,
-            name: str,
+        cls,
+        allspice_client,
+        owner: str,
+        name: str,
     ) -> Repository:
         return cls._request(allspice_client, {"owner": owner, "name": name})
 
@@ -462,8 +461,7 @@ class Repository(ApiObject):
 
         responses = allspice_client.requests_get_paginated(cls.REPO_SEARCH, params=params)
 
-        return [Repository.parse_response(allspice_client, response)
-                for response in responses]
+        return [Repository.parse_response(allspice_client, response) for response in responses]
 
     _patchable_fields: ClassVar[set[str]] = {
         "allow_manual_merge",
@@ -498,7 +496,7 @@ class Repository(ApiObject):
         args = {"owner": self.owner.username, "name": self.name}
         self._commit(args)
 
-    def get_branches(self) -> List['Branch']:
+    def get_branches(self) -> List["Branch"]:
         """Get all the Branches of this Repository."""
 
         results = self.allspice_client.requests_get_paginated(
@@ -506,7 +504,7 @@ class Repository(ApiObject):
         )
         return [Branch.parse_response(self.allspice_client, result) for result in results]
 
-    def get_branch(self, name: str) -> 'Branch':
+    def get_branch(self, name: str) -> "Branch":
         """Get a specific Branch of this Repository."""
         result = self.allspice_client.requests_get(
             Repository.REPO_BRANCH.format(owner=self.owner.username, repo=self.name, branch=name)
@@ -529,14 +527,14 @@ class Repository(ApiObject):
         return Branch.parse_response(self.allspice_client, result)
 
     def get_issues(
-            self,
-            state: Union[Literal["open"], Literal["closed"], Literal["all"]] = "all",
-            search_query: Optional[str] = None,
-            labels: Optional[List[str]] = None,
-            milestones: Optional[List[Union[Milestone, str]]] = None,
-            assignee: Optional[Union[User, str]] = None,
-            since: Optional[datetime] = None,
-            before: Optional[datetime] = None,
+        self,
+        state: Union[Literal["open"], Literal["closed"], Literal["all"]] = "all",
+        search_query: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+        milestones: Optional[List[Union[Milestone, str]]] = None,
+        assignee: Optional[Union[User, str]] = None,
+        since: Optional[datetime] = None,
+        before: Optional[datetime] = None,
     ) -> List["Issue"]:
         """
         Get all Issues of this Repository (open and closed)
@@ -566,8 +564,10 @@ class Repository(ApiObject):
             data["labels"] = ",".join(labels)
         if milestones:
             data["milestone"] = ",".join(
-                [milestone.name if isinstance(milestone, Milestone) else milestone for
-                 milestone in milestones]
+                [
+                    milestone.name if isinstance(milestone, Milestone) else milestone
+                    for milestone in milestones
+                ]
             )
         if assignee:
             if isinstance(assignee, User):
@@ -596,10 +596,10 @@ class Repository(ApiObject):
         return issues
 
     def get_design_reviews(
-            self,
-            state: Union[Literal["open"], Literal["closed"], Literal["all"]] = "all",
-            milestone: Optional[Union[Milestone, str]] = None,
-            labels: Optional[List[str]] = None,
+        self,
+        state: Union[Literal["open"], Literal["closed"], Literal["all"]] = "all",
+        milestone: Optional[Union[Milestone, str]] = None,
+        labels: Optional[List[str]] = None,
     ) -> List["DesignReview"]:
         """
         Get all Design Reviews of this Repository.
@@ -625,18 +625,16 @@ class Repository(ApiObject):
             params["labels"] = ",".join(labels)
 
         results = self.allspice_client.requests_get_paginated(
-            self.REPO_DESIGN_REVIEWS.format(owner=self.owner.username,
-                                            repo=self.name),
+            self.REPO_DESIGN_REVIEWS.format(owner=self.owner.username, repo=self.name),
             params=params,
         )
-        return [DesignReview.parse_response(self.allspice_client, result)
-                for result in results]
+        return [DesignReview.parse_response(self.allspice_client, result) for result in results]
 
     def get_commits(
-            self,
-            sha: Optional[str] = None,
-            path: Optional[str] = None,
-            stat: bool = True,
+        self,
+        sha: Optional[str] = None,
+        path: Optional[str] = None,
+        stat: bool = True,
     ) -> List["Commit"]:
         """
         Get all the Commits of this Repository.
@@ -665,9 +663,7 @@ class Repository(ApiObject):
             )
         except ConflictException as err:
             logging.warning(err)
-            logging.warning(
-                "Repository %s/%s is Empty" % (self.owner.username, self.name)
-            )
+            logging.warning("Repository %s/%s is Empty" % (self.owner.username, self.name))
             results = []
         return [Commit.parse_response(self.allspice_client, result) for result in results]
 
@@ -723,15 +719,15 @@ class Repository(ApiObject):
         return Issue.parse_response(self.allspice_client, result)
 
     def create_design_review(
-            self,
-            title: str,
-            head: Union[Branch, str],
-            base: Union[Branch, str],
-            assignees: Optional[Set[Union[User, str]]] = None,
-            body: Optional[str] = None,
-            due_date: Optional[datetime] = None,
-            milestone: Optional['Milestone'] = None,
-    ) -> 'DesignReview':
+        self,
+        title: str,
+        head: Union[Branch, str],
+        base: Union[Branch, str],
+        assignees: Optional[Set[Union[User, str]]] = None,
+        body: Optional[str] = None,
+        due_date: Optional[datetime] = None,
+        milestone: Optional["Milestone"] = None,
+    ) -> "DesignReview":
         """
         Create a new Design Review.
 
@@ -761,8 +757,7 @@ class Repository(ApiObject):
         else:
             data["base"] = base
         if assignees:
-            data["assignees"] = [a.username if isinstance(a, User) else a for a in
-                                 assignees]
+            data["assignees"] = [a.username if isinstance(a, User) else a for a in assignees]
         if body:
             data["body"] = body
         if due_date:
@@ -771,13 +766,14 @@ class Repository(ApiObject):
             data["milestone"] = milestone.id
 
         result = self.allspice_client.requests_post(
-            self.REPO_DESIGN_REVIEWS.format(owner=self.owner.username, repo=self.name),
-            data=data
+            self.REPO_DESIGN_REVIEWS.format(owner=self.owner.username, repo=self.name), data=data
         )
 
         return DesignReview.parse_response(self.allspice_client, result)
 
-    def create_milestone(self, title: str, description: str, due_date: Optional[str] = None, state: str = "open") -> "Milestone":
+    def create_milestone(
+        self, title: str, description: str, due_date: Optional[str] = None, state: str = "open"
+    ) -> "Milestone":
         url = Repository.REPO_MILESTONES.format(owner=self.owner.username, repo=self.name)
         data = {"title": title, "description": description, "state": state}
         if due_date:
@@ -809,8 +805,7 @@ class Repository(ApiObject):
         try:
             # returns 204 if its ok, 404 if its not
             self.allspice_client.requests_get(
-                Repository.REPO_IS_COLLABORATOR
-                % (self.owner.username, self.name, username)
+                Repository.REPO_IS_COLLABORATOR % (self.owner.username, self.name, username)
             )
             return True
         except Exception:
@@ -835,7 +830,9 @@ class Repository(ApiObject):
         url = f"/repos/{self.owner.username}/{self.name}/collaborators/{user_name}"
         self.allspice_client.requests_delete(url)
 
-    def transfer_ownership(self, new_owner: Union["User", "Organization"], new_teams: Set["Team"] = frozenset()):
+    def transfer_ownership(
+        self, new_owner: Union["User", "Organization"], new_teams: Set["Team"] = frozenset()
+    ):
         url = Repository.REPO_TRANSFER.format(owner=self.owner.username, repo=self.name)
         data = {"new_owner": new_owner.username}
         if isinstance(new_owner, Organization):
@@ -845,9 +842,7 @@ class Repository(ApiObject):
         # TODO: make sure this instance is either updated or discarded
 
     def get_git_content(
-            self: Optional[str] = None,
-            ref: Optional["Ref"] = None,
-            commit: "Optional[Commit]" = None
+        self: Optional[str] = None, ref: Optional["Ref"] = None, commit: "Optional[Commit]" = None
     ) -> List["Content"]:
         """
         Get a list of all files in the repository.
@@ -860,15 +855,17 @@ class Repository(ApiObject):
         url = f"/repos/{self.owner.username}/{self.name}/contents"
         data = Util.data_params_for_ref(ref or commit)
 
-        result = [Content.parse_response(self.allspice_client, f)
-                  for f in self.allspice_client.requests_get(url, data)]
+        result = [
+            Content.parse_response(self.allspice_client, f)
+            for f in self.allspice_client.requests_get(url, data)
+        ]
         return result
 
     def get_file_content(
-            self,
-            content: Content,
-            ref: Optional[Ref] = None,
-            commit: Optional[Commit] = None,
+        self,
+        content: Content,
+        ref: Optional[Ref] = None,
+        commit: Optional[Commit] = None,
     ) -> Union[str, List["Content"]]:
         """https://hub.allspice.io/api/swagger#/repository/repoGetContents"""
         url = f"/repos/{self.owner.username}/{self.name}/contents/{content.path}"
@@ -877,13 +874,12 @@ class Repository(ApiObject):
         if content.type == Content.FILE:
             return self.allspice_client.requests_get(url, data)["content"]
         else:
-            return [Content.parse_response(self.allspice_client, f) for f in self.allspice_client.requests_get(url, data)]
+            return [
+                Content.parse_response(self.allspice_client, f)
+                for f in self.allspice_client.requests_get(url, data)
+            ]
 
-    def get_generated_json(
-            self,
-            content: Union[Content, str],
-            ref: Optional[Ref] = None
-    ) -> dict:
+    def get_generated_json(self, content: Union[Content, str], ref: Optional[Ref] = None) -> dict:
         """
         Get the json blob for a cad file if it exists, otherwise enqueue
         a new job and return a 503 status.
@@ -906,11 +902,7 @@ class Repository(ApiObject):
         data = Util.data_params_for_ref(ref)
         return self.allspice_client.requests_get(url, data)
 
-    def get_generated_svg(
-            self,
-            content: Union[Content, str],
-            ref: Optional[Ref] = None
-    ) -> bytes:
+    def get_generated_svg(self, content: Union[Content, str], ref: Optional[Ref] = None) -> bytes:
         """
         Get the svg blob for a cad file if it exists, otherwise enqueue
         a new job and return a 503 status.
@@ -958,9 +950,9 @@ class Repository(ApiObject):
         return self.allspice_client.requests_delete(url, data)
 
     def get_archive(
-            self,
-            ref: Ref = "main",
-            archive_format: ArchiveFormat = ArchiveFormat.ZIP,
+        self,
+        ref: Ref = "main",
+        archive_format: ArchiveFormat = ArchiveFormat.ZIP,
     ) -> bytes:
         """
         Download all the files in a specific ref of a repository as a zip or tarball
@@ -1005,11 +997,7 @@ class Repository(ApiObject):
             dashes. Topic names also must be under 35 characters long.
         """
 
-        url = self.REPO_ADD_TOPIC.format(
-            owner=self.owner.username,
-            repo=self.name,
-            topic=topic
-        )
+        url = self.REPO_ADD_TOPIC.format(owner=self.owner.username, repo=self.name, topic=topic)
         self.allspice_client.requests_put(url)
 
     def delete(self):
@@ -1098,13 +1086,7 @@ class Comment(ApiObject):
         return hash(self.repo) ^ hash(self.id)
 
     @classmethod
-    def request(
-            cls,
-            allspice_client,
-            owner: str,
-            repo: str,
-            id: str
-    ) -> 'Comment':
+    def request(cls, allspice_client, owner: str, repo: str, id: str) -> "Comment":
         return cls._request(allspice_client, {"owner": owner, "repo": repo, "id": id})
 
     _fields_to_parsers: ClassVar[dict] = {
@@ -1113,9 +1095,7 @@ class Comment(ApiObject):
         "updated_at": lambda _, t: Util.convert_time(t),
     }
 
-    _patchable_fields: ClassVar[set[str]] = {
-        "body"
-    }
+    _patchable_fields: ClassVar[set[str]] = {"body"}
 
     @property
     def parent_url(self) -> str:
@@ -1144,9 +1124,7 @@ class Comment(ApiObject):
         self._commit(self.__fields_for_path())
 
     def delete(self):
-        self.allspice_client.requests_delete(
-            self.API_OBJECT.format(**self.__fields_for_path())
-        )
+        self.allspice_client.requests_delete(self.API_OBJECT.format(**self.__fields_for_path()))
         self.deleted = True
 
     def get_attachments(self) -> List[Attachment]:
@@ -1160,8 +1138,7 @@ class Comment(ApiObject):
         results = self.allspice_client.requests_get(
             self.GET_ATTACHMENTS_PATH.format(**self.__fields_for_path())
         )
-        return [Attachment.parse_response(self.allspice_client, result) for result in
-                results]
+        return [Attachment.parse_response(self.allspice_client, result) for result in results]
 
     def create_attachment(self, file: IO, name: Optional[str] = None) -> Attachment:
         """
@@ -1221,7 +1198,6 @@ class Comment(ApiObject):
 
 
 class Commit(ReadonlyApiObject):
-
     def __init__(self, allspice_client):
         super().__init__(allspice_client)
 
@@ -1239,7 +1215,7 @@ class Commit(ReadonlyApiObject):
         return hash(self.sha)
 
     @classmethod
-    def parse_response(cls, allspice_client, result) -> 'Commit':
+    def parse_response(cls, allspice_client, result) -> "Commit":
         commit_cache = result["commit"]
         api_object = cls(allspice_client)
         cls._initialize(allspice_client, api_object, result)
@@ -1272,10 +1248,14 @@ class Issue(ApiObject):
         "milestone": lambda allspice_client, m: Milestone.parse_response(allspice_client, m),
         "user": lambda allspice_client, u: User.parse_response(allspice_client, u),
         "assignee": lambda allspice_client, u: User.parse_response(allspice_client, u),
-        "assignees": lambda allspice_client, us: [User.parse_response(allspice_client, u) for u in us],
+        "assignees": lambda allspice_client, us: [
+            User.parse_response(allspice_client, u) for u in us
+        ],
         "state": lambda allspice_client, s: Issue.CLOSED if s == "closed" else Issue.OPENED,
         # Repository in this request is just a "RepositoryMeta" record, thus request whole object
-        "repository": lambda allspice_client, r: Repository.request(allspice_client, r["owner"], r["name"])
+        "repository": lambda allspice_client, r: Repository.request(
+            allspice_client, r["owner"], r["name"]
+        ),
     }
 
     _parsers_to_fields: ClassVar[dict] = {
@@ -1316,11 +1296,7 @@ class Issue(ApiObject):
         results = self.allspice_client.requests_get(
             Issue.GET_TIME % (self.owner.username, self.repo.name, self.number)
         )
-        return sum(
-            result["time"]
-            for result in results
-            if result and result["user_id"] == user.id
-        )
+        return sum(result["time"] for result in results if result and result["user_id"] == user.id)
 
     def get_times(self) -> Optional[Dict]:
         return self.allspice_client.requests_get(
@@ -1342,23 +1318,17 @@ class Issue(ApiObject):
 
         results = self.allspice_client.requests_get(
             self.GET_COMMENTS.format(
-                owner=self.owner.username,
-                repo=self.repo.name,
-                index=self.number
+                owner=self.owner.username, repo=self.repo.name, index=self.number
             )
         )
 
-        return [
-            Comment.parse_response(self.allspice_client, result) for result in results
-        ]
+        return [Comment.parse_response(self.allspice_client, result) for result in results]
 
     def create_comment(self, body: str) -> Comment:
         """https://hub.allspice.io/api/swagger#/issue/issueCreateComment"""
 
         path = self.GET_COMMENTS.format(
-            owner=self.owner.username,
-            repo=self.repo.name,
-            index=self.number
+            owner=self.owner.username, repo=self.repo.name, index=self.number
         )
 
         response = self.allspice_client.requests_post(path, data={"body": body})
@@ -1403,13 +1373,12 @@ class DesignReview(ApiObject):
         return hash(self.repo) ^ hash(self.id)
 
     @classmethod
-    def parse_response(cls, allspice_client, result) -> 'DesignReview':
+    def parse_response(cls, allspice_client, result) -> "DesignReview":
         api_object = super().parse_response(allspice_client, result)
         cls._add_read_property(
             "repository",
-            Repository.parse_response(allspice_client,
-                                      result["base"]["repo"]),
-            api_object
+            Repository.parse_response(allspice_client, result["base"]["repo"]),
+            api_object,
         )
 
         return api_object
@@ -1417,18 +1386,17 @@ class DesignReview(ApiObject):
     @classmethod
     def request(cls, allspice_client, owner: str, repo: str, number: str):
         """See https://hub.allspice.io/api/swagger#/repository/repoGetPullRequest"""
-        return cls._request(allspice_client,
-                            {"owner": owner, "repo": repo, "index": number})
+        return cls._request(allspice_client, {"owner": owner, "repo": repo, "index": number})
 
     _fields_to_parsers: ClassVar[dict] = {
         "assignee": lambda allspice_client, u: User.parse_response(allspice_client, u),
-        "assignees": lambda allspice_client, us: [User.parse_response(allspice_client, u)
-                                                  for u in us],
+        "assignees": lambda allspice_client, us: [
+            User.parse_response(allspice_client, u) for u in us
+        ],
         "base": lambda allspice_client, b: b["ref"],
         "head": lambda allspice_client, h: h["ref"],
         "merged_by": lambda allspice_client, u: User.parse_response(allspice_client, u),
-        "milestone": lambda allspice_client, m: Milestone.parse_response(allspice_client,
-                                                                         m),
+        "milestone": lambda allspice_client, m: Milestone.parse_response(allspice_client, m),
         "user": lambda allspice_client, u: User.parse_response(allspice_client, u),
     }
 
@@ -1459,7 +1427,7 @@ class DesignReview(ApiObject):
         args = {
             "owner": self.repository.owner.username,
             "repo": self.repository.name,
-            "index": self.number
+            "index": self.number,
         }
         self._commit(args, data)
 
@@ -1472,9 +1440,9 @@ class DesignReview(ApiObject):
         """
 
         self.allspice_client.requests_put(
-            self.MERGE_DESIGN_REVIEW.format(owner=self.repository.owner.username,
-                                            repo=self.repository.name,
-                                            index=self.number),
+            self.MERGE_DESIGN_REVIEW.format(
+                owner=self.repository.owner.username, repo=self.repository.name, index=self.number
+            ),
             data={"Do": merge_type.value},
         )
 
@@ -1489,14 +1457,10 @@ class DesignReview(ApiObject):
 
         results = self.allspice_client.requests_get(
             self.GET_COMMENTS.format(
-                owner=self.repository.owner.username,
-                repo=self.repository.name,
-                index=self.number
+                owner=self.repository.owner.username, repo=self.repository.name, index=self.number
             )
         )
-        return [
-            Comment.parse_response(self.allspice_client, result) for result in results
-        ]
+        return [Comment.parse_response(self.allspice_client, result) for result in results]
 
     def create_comment(self, body: str):
         """
@@ -1511,11 +1475,9 @@ class DesignReview(ApiObject):
 
         result = self.allspice_client.requests_post(
             self.GET_COMMENTS.format(
-                owner=self.repository.owner.username,
-                repo=self.repository.name,
-                index=self.number
+                owner=self.repository.owner.username, repo=self.repository.name, index=self.number
             ),
-            data={"body": body}
+            data={"body": body},
         )
         return Comment.parse_response(self.allspice_client, result)
 
@@ -1573,14 +1535,14 @@ class Team(ApiObject):
         self.allspice_client.requests_put(Team.ADD_REPO % (self.id, org.username, repo_name))
 
     def get_members(self):
-        """ Get all users assigned to the team. """
+        """Get all users assigned to the team."""
         results = self.allspice_client.requests_get_paginated(
             Team.GET_MEMBERS % self.id,
         )
         return [User.parse_response(self.allspice_client, result) for result in results]
 
     def get_repos(self):
-        """ Get all repos of this Team."""
+        """Get all repos of this Team."""
         results = self.allspice_client.requests_get(Team.GET_REPOS % self.id)
         return [Repository.parse_response(self.allspice_client, result) for result in results]
 
@@ -1614,7 +1576,7 @@ Ref = Union[Branch, Commit, str]
 class Util:
     @staticmethod
     def convert_time(time: str) -> datetime:
-        """ Parsing of strange Gitea time format ("%Y-%m-%dT%H:%M:%S:%z" but with ":" in time zone notation)"""
+        """Parsing of strange Gitea time format ("%Y-%m-%dT%H:%M:%S:%z" but with ":" in time zone notation)"""
         try:
             return datetime.strptime(time[:-3] + "00", "%Y-%m-%dT%H:%M:%S%z")
         except ValueError:

--- a/allspice/baseapiobject.py
+++ b/allspice/baseapiobject.py
@@ -4,7 +4,6 @@ from .exceptions import ObjectIsInvalid, MissingEqualityImplementation, RawReque
 
 
 class ReadonlyApiObject:
-
     def __init__(self, allspice_client):
         self.allspice_client = allspice_client
         self.deleted = False  # set if .delete was called, so that an exception is risen
@@ -37,7 +36,7 @@ class ReadonlyApiObject:
 
     @classmethod
     def _get_gitea_api_object(cls, allspice_client, args):
-        """Retrieving an object always as GET_API_OBJECT """
+        """Retrieving an object always as GET_API_OBJECT"""
         return allspice_client.requests_get(cls.API_OBJECT.format(**args))
 
     @classmethod
@@ -63,8 +62,7 @@ class ReadonlyApiObject:
     def _add_read_property(cls, name, value, api_object):
         if not hasattr(api_object, name):
             setattr(api_object, "_" + name, value)
-            prop = property(
-                (lambda n: lambda self: self._get_var(n))(name))
+            prop = property((lambda n: lambda self: self._get_var(n))(name))
             setattr(cls, name, prop)
         else:
             raise AttributeError(f"Attribute {name} already exists on api object.")
@@ -124,7 +122,8 @@ class ApiObject(ReadonlyApiObject):
             setattr(api_object, "_" + name, value)
         prop = property(
             (lambda n: lambda self: self._get_var(n))(name),
-            (lambda n: lambda self, v: self.__set_var(n, v))(name))
+            (lambda n: lambda self, v: self.__set_var(n, v))(name),
+        )
         setattr(cls, name, prop)
 
     def __set_var(self, name, i):

--- a/allspice/exceptions.py
+++ b/allspice/exceptions.py
@@ -21,12 +21,14 @@ class NotYetGeneratedException(Exception):
 
     Usually, retrying after a while will be successful.
     """
+
     pass
 
 
 class RawRequestEndpointMissing(Exception):
     """This ApiObject can only be obtained through other api objects and does not have
     diret .request method."""
+
     pass
 
 
@@ -35,4 +37,5 @@ class MissingEqualityImplementation(Exception):
     Each Object obtained from the AllSpice Hub api must be able to check itself for equality in relation to its
     fields obtained from gitea. Risen if an api object is lacking the proper implementation.
     """
+
     pass

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -86,6 +86,7 @@ class AttributesMapping:
             designator=dictionary["designator"],
         )
 
+
 # TODO: We should make this generic for all PCBs and change all `pcbdoc` references to `pcb`
 # TODO: We should default to generating a BOM using only the project file + schematics.
 #   Using PCB to generate the BOM should be an option flag, but we shouldn't be combining
@@ -172,9 +173,7 @@ def _get_file_content(repo, file_path, ref) -> str:
     files_in_repo = repo.get_git_content(ref=ref)
     file = next((x for x in files_in_repo if x.path == file_path), None)
     if not file:
-        raise ValueError(
-            f"File {file_path} not found in repo {repo.name} at ref {ref.name}"
-        )
+        raise ValueError(f"File {file_path} not found in repo {repo.name} at ref {ref.name}")
 
     content = repo.get_file_content(file, ref=ref)
     return base64.b64decode(content).decode("utf-8")
@@ -332,9 +331,7 @@ def _combine_components_to_ungrouped_bom(
             schdoc_designator = pcbdoc_component.schematic_link
             pcb_designator = pcbdoc_component.designator
 
-            pcb_designators_for_schdoc_designators[schdoc_designator].append(
-                pcb_designator
-            )
+            pcb_designators_for_schdoc_designators[schdoc_designator].append(pcb_designator)
         else:
             orphan_pcb_components.append(pcbdoc_component)
 
@@ -384,8 +381,6 @@ def _group_bom_entries(bom_entries: list[BomEntry]) -> list[BomEntry]:
                 bom_entries_by_part_number[bom_entry.part_number].designators.extend(
                     bom_entry.designators
                 )
-                bom_entries_by_part_number[
-                    bom_entry.part_number
-                ].quantity += bom_entry.quantity
+                bom_entries_by_part_number[bom_entry.part_number].quantity += bom_entry.quantity
 
     return list(bom_entries_by_part_number.values())

--- a/allspice/utils/netlist_generation.py
+++ b/allspice/utils/netlist_generation.py
@@ -50,9 +50,7 @@ def generate_netlist(
     :return: A list of netlist entries.
     """
 
-    allspice_client.logger.info(
-        f"Generating netlist for {repository.name=} on {ref=}"
-    )
+    allspice_client.logger.info(f"Generating netlist for {repository.name=} on {ref=}")
     allspice_client.logger.info(f"Fetching {pcb_file=}")
 
     pcb_components = _extract_all_pcb_components(allspice_client.logger, repository, ref, pcb_file)
@@ -80,25 +78,20 @@ def _extract_all_pcb_components(
                 designator = pin["designator"]
             except KeyError:
                 logger.warn(
-                    f"No pad designator: pad in component {component['designator']} has no defined designator.")
+                    f"No pad designator: pad in component {component['designator']} has no defined designator."
+                )
                 continue
 
             try:
                 net = pin["net_name"]
             except KeyError:
                 logger.warning(
-                    f"Unconnected pad: {designator} in component {component['designator']}.")
+                    f"Unconnected pad: {designator} in component {component['designator']}."
+                )
                 continue
 
-            pins.append(ComponentPin(
-                designator=designator,
-                net=net
-            ))
-        components.append(
-            PcbComponent(
-                designator=component["designator"],
-                pins=pins)
-        )
+            pins.append(ComponentPin(designator=designator, net=net))
+        components.append(PcbComponent(designator=component["designator"], pins=pins))
 
     return components
 
@@ -114,5 +107,6 @@ def _group_netlist_entries(components: list[PcbComponent]) -> dict[NetlistEntry]
         for pin in component.pins:
             if pin.net:
                 netlist_entries_by_net.setdefault(pin.net, []).append(
-                    component.designator + "." + str(pin.designator))
+                    component.designator + "." + str(pin.designator)
+                )
     return netlist_entries_by_net

--- a/examples/generate_bom/compute_cogs.py
+++ b/examples/generate_bom/compute_cogs.py
@@ -86,9 +86,7 @@ def fetch_price_for_part(part_number: str) -> dict[int, float]:
         )
         return {}
 
-    prices = {
-        int(price["quantity"]): float(price["price"]) for price in reference_prices
-    }
+    prices = {int(price["quantity"]): float(price["price"]) for price in reference_prices}
 
     return prices
 
@@ -121,9 +119,7 @@ if __name__ == "__main__":
         bom_csv = csv.DictReader(bom_file)
 
         parts = [
-            part
-            for part in bom_csv
-            if part[PART_NUMBER_COLUMN] and part[PART_NUMBER_COLUMN] != ""
+            part for part in bom_csv if part[PART_NUMBER_COLUMN] and part[PART_NUMBER_COLUMN] != ""
         ]
 
     print(f"Computing COGS for {len(parts)} parts", file=sys.stderr)
@@ -167,11 +163,7 @@ if __name__ == "__main__":
             try:
                 prices = prices_for_parts[part_number]
                 largest_breakpoint_less_than_qty = max(
-                    [
-                        breakpoint
-                        for breakpoint in prices.keys()
-                        if breakpoint <= quantity
-                    ]
+                    [breakpoint for breakpoint in prices.keys() if breakpoint <= quantity]
                 )
                 price_at_breakpoint = prices[largest_breakpoint_less_than_qty]
                 current_row.append(price_at_breakpoint)

--- a/examples/generate_bom/generate_bom.py
+++ b/examples/generate_bom/generate_bom.py
@@ -25,9 +25,7 @@ if __name__ == "__main__":
         prog="generate_bom", description="Generate a BOM from a PrjPcb file."
     )
     parser.add_argument("repository", help="The repo containing the project")
-    parser.add_argument(
-        "prjpcb_file", help="The path to the PrjPcb file in the source repo."
-    )
+    parser.add_argument("prjpcb_file", help="The path to the PrjPcb file in the source repo.")
     parser.add_argument(
         "pcb_file",
         help="The path to the PCB file in the source repo.",
@@ -62,9 +60,7 @@ if __name__ == "__main__":
     if args.allspice_hub_url is None:
         allspice = AllSpice(token_text=auth_token)
     else:
-        allspice = AllSpice(
-            token_text=auth_token, allspice_hub_url=args.allspice_hub_url
-        )
+        allspice = AllSpice(token_text=auth_token, allspice_hub_url=args.allspice_hub_url)
 
     repo_owner, repo_name = args.repository.split("/")
     repository = allspice.get_repository(repo_owner, repo_name)

--- a/examples/generate_netlist/generate_netlist.py
+++ b/examples/generate_netlist/generate_netlist.py
@@ -49,9 +49,7 @@ if __name__ == "__main__":
     if args.allspice_hub_url is None:
         allspice = AllSpice(token_text=auth_token)
     else:
-        allspice = AllSpice(
-            token_text=auth_token, allspice_hub_url=args.allspice_hub_url
-        )
+        allspice = AllSpice(token_text=auth_token, allspice_hub_url=args.allspice_hub_url)
 
     repo_owner, repo_name = args.repository.split("/")
     repository = allspice.get_repository(repo_owner, repo_name)

--- a/examples/topics/clone_all_repos_by_topic.py
+++ b/examples/topics/clone_all_repos_by_topic.py
@@ -9,7 +9,7 @@ import subprocess
 
 from allspice import AllSpice, Repository
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("topic", help="Topic to clone repos from")
     parser.add_argument("--allspice_url", help="URL of AllSpice server")

--- a/flake.nix
+++ b/flake.nix
@@ -10,14 +10,14 @@
         pkgs = import nixpkgs { system = "${system}"; config.allowUnfree = true; };
       in
       {
-        devShell = pkgs.mkShell { 
-          buildInputs = [ 
+        devShell = pkgs.mkShell {
+          buildInputs = [
             pkgs.figlet
 
             pkgs.ruff
 
-            (pkgs.python3.withPackages (pypkgs: with pypkgs; [requests frozendict pytest autopep8]))
-          ]; 
+            (pkgs.python3.withPackages (pypkgs: with pypkgs; [requests frozendict pytest ruff]))
+          ];
 
           shellHook = ''
             figlet "py-allspice"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,8 @@
-[tool.autopep8]
-max_line_length = 100
-# This should match ruff excludes.
-exclude = ""
-
 [tool.ruff]
-ignore = [
+lint.ignore = [
   "E501", # Line length.
   "F405", # Unknown identifier usage due to import *.
 ]
 line-length = 100
-select = ["E", "F", "RUF"]
-# This should match autopep8 excludes.
+lint.select = ["E", "F", "RUF"]
 exclude = []

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,2 @@
-autopep8
 pytest
 ruff

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,29 @@
 from setuptools import setup, find_packages
 
-with open('README.md') as readme_file:
+with open("README.md") as readme_file:
     README = readme_file.read()
 
 setup_args = dict(
-    name='py-allspice',
-    version='{{VERSION_PLACEHOLDER}}',
-    description='A python wrapper for the AllSpice Hub API',
+    name="py-allspice",
+    version="{{VERSION_PLACEHOLDER}}",
+    description="A python wrapper for the AllSpice Hub API",
     long_description_content_type="text/markdown",
     long_description=README,
-    license='MIT',
+    license="MIT",
     packages=find_packages(),
-    author='AllSpice, Inc.',
-    author_email='maintainers@allspice.io',
-    keywords=['AllSpice', 'AllSpice Hub', 'api', 'wrapper'],
-    url='https://github.com/AllSpiceIO/py-allspice',
-    download_url='https://github.com/AllSpiceIO/py-allspice'
+    author="AllSpice, Inc.",
+    author_email="maintainers@allspice.io",
+    keywords=["AllSpice", "AllSpice Hub", "api", "wrapper"],
+    url="https://github.com/AllSpiceIO/py-allspice",
+    download_url="https://github.com/AllSpiceIO/py-allspice",
 )
 
 install_requires = [
-    'requests',
-    'frozendict',
+    "requests",
+    "frozendict",
 ]
 
-extras_require = {
-    'test': ['pytest']
-}
+extras_require = {"test": ["pytest"]}
 
-if __name__ == '__main__':
-    setup(
-        **setup_args,
-        install_requires=install_requires,
-        extras_require=extras_require
-    )
+if __name__ == "__main__":
+    setup(**setup_args, install_requires=install_requires, extras_require=extras_require)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from allspice import AllSpice
 
 
 def pytest_addoption(parser):
-    '''add option to specify localhost port for tests'''
+    """add option to specify localhost port for tests"""
     parser.addoption("--port", action="store", default="3000")
 
 
@@ -34,9 +34,7 @@ def instance(scope="module"):
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except Exception:
-        assert (
-            False
-        ), "AllSpice Hub could not load. \
+        assert False, "AllSpice Hub could not load. \
                 - Instance running at http://localhost:3000 \
                 - Token at .token   \
                     ?"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,18 @@ import time
 import pytest
 import uuid
 
-from allspice import AllSpice, User, Organization, Team, Repository, Issue, Milestone, \
-    DesignReview, Branch, Comment
+from allspice import (
+    AllSpice,
+    User,
+    Organization,
+    Team,
+    Repository,
+    Issue,
+    Milestone,
+    DesignReview,
+    Branch,
+    Comment,
+)
 from allspice import NotFoundException
 from allspice.apiobject import Util
 from allspice.exceptions import NotYetGeneratedException
@@ -16,22 +26,21 @@ from allspice.exceptions import NotYetGeneratedException
 
 @pytest.fixture(scope="session")
 def port(pytestconfig):
-    '''Load --port command-line arg if set'''
+    """Load --port command-line arg if set"""
     return pytestconfig.getoption("port")
 
 
 @pytest.fixture
 def instance(port, scope="module"):
     try:
-        g = AllSpice(f"http://localhost:{port}", open(".token",
-                     "r").read().strip(), ratelimiting=None)
+        g = AllSpice(
+            f"http://localhost:{port}", open(".token", "r").read().strip(), ratelimiting=None
+        )
         print("AllSpice Hub Version: " + g.get_version())
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except Exception:
-        assert (
-            False
-        ), f"AllSpice Hub could not load. \
+        assert False, f"AllSpice Hub could not load. \
                 - Instance running at http://localhost:{port} \
                 - Token at .token   \
                     ?"
@@ -90,7 +99,7 @@ def test_change_user(instance):
     new_fullname = "Other Test Full Name"
     user.full_name = new_fullname
     user.commit(user.username, 0)
-    del (user)
+    del user
     user = instance.get_user_by_name(test_user)
     assert user.full_name == new_fullname
     assert user.location == location
@@ -288,11 +297,10 @@ def test_list_files_and_content(instance):
 
 def test_create_file(instance):
     TESTFILE_CONENTE = "TestStringFileContent"
-    TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, 'utf-8'))
+    TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, "utf-8"))
     org = Organization.request(instance, test_org)
     repo = org.get_repository(test_repo)
-    repo.create_file("testfile.md",
-                     content=TESTFILE_CONENTE_B64.decode("ascii"))
+    repo.create_file("testfile.md", content=TESTFILE_CONENTE_B64.decode("ascii"))
     # test if putting was successful
     content = repo.get_git_content()
     readmes = [c for c in content if c.name == "testfile.md"]
@@ -304,15 +312,14 @@ def test_create_file(instance):
 
 def test_change_file(instance):
     TESTFILE_CONENTE = "TestStringFileContent with changed content now"
-    TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, 'utf-8'))
+    TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, "utf-8"))
     org = Organization.request(instance, test_org)
     repo = org.get_repository(test_repo)
     # figure out the sha of the file to change
     content = repo.get_git_content()
     readmes = [c for c in content if c.name == "testfile.md"]
     # change
-    repo.change_file("testfile.md", readmes[0].sha,
-                     content=TESTFILE_CONENTE_B64.decode("ascii"))
+    repo.change_file("testfile.md", readmes[0].sha, content=TESTFILE_CONENTE_B64.decode("ascii"))
     # test if putting was successful
     content = repo.get_git_content()
     readmes = [c for c in content if c.name == "testfile.md"]
@@ -395,10 +402,7 @@ def test_create_team_without_units_map(instance):
 def test_create_team_with_units_map(instance):
     org = Organization.request(instance, test_org)
     team = instance.create_team(
-        org,
-        test_team + "2",
-        "descr",
-        units_map={"repo.code": "write", "repo.wiki": "admin"}
+        org, test_team + "2", "descr", units_map={"repo.code": "write", "repo.wiki": "admin"}
     )
     assert set(team.units) == set(["repo.code", "repo.wiki"])
     assert team.units_map == {"repo.code": "write", "repo.wiki": "admin"}
@@ -504,8 +508,16 @@ def test_change_issue(instance):
     assert issue3.milestone is not None
     assert issue3.milestone.description == "this is only a teststone2"
     issues = repo.get_issues()
-    assert len([issue for issue in issues
-                if issue.milestone is not None and issue.milestone.title == ms_title]) > 0
+    assert (
+        len(
+            [
+                issue
+                for issue in issues
+                if issue.milestone is not None and issue.milestone.title == ms_title
+            ]
+        )
+        > 0
+    )
 
 
 def test_create_issue_comment(instance):
@@ -565,8 +577,7 @@ def test_create_issue_attachment_with_name(instance):
     repo = Repository.request(instance, org.username, test_repo)
     issue = repo.get_issues()[0]
     comment = issue.create_comment("this is a comment that will have an attachment")
-    attachment = comment.create_attachment(open("requirements.txt", "rb"),
-                                           "something else.txt")
+    attachment = comment.create_attachment(open("requirements.txt", "rb"), "something else.txt")
     assert attachment.name == "something else.txt"
     assert attachment.download_count == 0
 
@@ -715,9 +726,11 @@ def test_delete_repo_orgowned(instance):
 def test_change_repo_ownership_org(instance):
     old_org = Organization.request(instance, test_org)
     user = User.request(instance, test_user)
-    new_org = instance.create_org(user, test_org+"_repomove", "Org for testing moving repositories")
+    new_org = instance.create_org(
+        user, test_org + "_repomove", "Org for testing moving repositories"
+    )
     new_team = instance.create_team(new_org, test_team + "_repomove", "descr")
-    repo_name = test_repo+"_repomove"
+    repo_name = test_repo + "_repomove"
     repo = instance.create_repo(old_org, repo_name, "descr")
     repo.transfer_ownership(new_org, set([new_team]))
     assert repo_name not in [repo.name for repo in old_org.get_repositories()]
@@ -727,7 +740,7 @@ def test_change_repo_ownership_org(instance):
 def test_change_repo_ownership_user(instance):
     old_org = Organization.request(instance, test_org)
     user = User.request(instance, test_user)
-    repo_name = test_repo+"_repomove"
+    repo_name = test_repo + "_repomove"
     repo = instance.create_repo(old_org, repo_name, "descr")
     repo.transfer_ownership(user)
     assert repo_name not in [repo.name for repo in old_org.get_repositories()]

--- a/tests/test_api_longtests.py
+++ b/tests/test_api_longtests.py
@@ -8,22 +8,21 @@ from allspice import AllSpice, Issue
 
 @pytest.fixture(scope="session")
 def port(pytestconfig):
-    '''Load --port command-line arg if set'''
+    """Load --port command-line arg if set"""
     return pytestconfig.getoption("port")
 
 
 @pytest.fixture
 def instance(port, scope="module"):
     try:
-        g = AllSpice(f"http://localhost:{port}", open(".token",
-                     "r").read().strip(), ratelimiting=None)
+        g = AllSpice(
+            f"http://localhost:{port}", open(".token", "r").read().strip(), ratelimiting=None
+        )
         print("AllSpice Hub Version: " + g.get_version())
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except Exception:
-        assert (
-            False
-        ), f"AllSpice Hub could not load. \
+        assert False, f"AllSpice Hub could not load. \
                 - Instance running at http://localhost:{port} \
                 - Token at .token   \
                     ?"
@@ -38,9 +37,12 @@ test_repo = "repo_" + uuid.uuid4().hex[:8]
 
 def _create_test_org(instance, test_name):
     test_user_unique = "-".join([test_user, test_name])
-    user = instance.create_user(test_user_unique, test_user_unique + "@example.org",
-                                "abcdefg1.23AB", send_notify=False)
-    return instance.create_org(user, "-".join([test_org, test_name]), "some Description for longtests")
+    user = instance.create_user(
+        test_user_unique, test_user_unique + "@example.org", "abcdefg1.23AB", send_notify=False
+    )
+    return instance.create_org(
+        user, "-".join([test_org, test_name]), "some Description for longtests"
+    )
 
 
 def test_list_repos(request, instance):
@@ -57,10 +59,12 @@ def test_list_repos(request, instance):
 def test_list_issue(request, instance):
     org = _create_test_org(instance, request.node.name)
     repo = instance.create_repo(
-        org, test_repo, "Testing a huge number of Issues and how they are listed")
+        org, test_repo, "Testing a huge number of Issues and how they are listed"
+    )
     for x in range(0, 100):
-        Issue.create_issue(instance, repo, "TestIssue" + str(x),
-                           "We will be too many to be listed on one page")
+        Issue.create_issue(
+            instance, repo, "TestIssue" + str(x), "We will be too many to be listed on one page"
+        )
     issues = repo.get_issues()
     assert len(issues) > 98
 
@@ -76,7 +80,7 @@ def test_list_team_members(request, instance):
                 test_user + str(i),
                 test_user + str(i) + "@example.org",
                 "abcdefg1.23AB",
-                send_notify=False
+                send_notify=False,
             ),
         )
     for user in users:

--- a/tests/test_api_ratelimiting.py
+++ b/tests/test_api_ratelimiting.py
@@ -6,8 +6,9 @@ from allspice import AllSpice
 
 @pytest.fixture(scope="session")
 def port(pytestconfig):
-    '''Load --port command-line arg if set'''
+    """Load --port command-line arg if set"""
     return pytestconfig.getoption("port")
+
 
 # put a ".token" file into your directory containg only the token for AllSpice Hub
 
@@ -24,9 +25,7 @@ def instance(port, scope="module"):
         print("API-Token belongs to user: " + g.get_user().username)
         return g
     except Exception:
-        assert (
-            False
-        ), f"AllSpice Hub could not load. \
+        assert False, f"AllSpice Hub could not load. \
                 - Instance running at http://localhost:{port} \
                 - Token at .token   \
                     ?"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,11 @@ import uuid
 import pytest
 
 from allspice import AllSpice
-from allspice.utils.bom_generation import AttributesMapping, generate_bom_for_altium, _get_file_content
+from allspice.utils.bom_generation import (
+    AttributesMapping,
+    generate_bom_for_altium,
+    _get_file_content,
+)
 from allspice.utils.netlist_generation import generate_netlist
 
 test_repo = "repo_" + uuid.uuid4().hex[:8]
@@ -15,7 +19,7 @@ test_branch = "branch_" + uuid.uuid4().hex[:8]
 
 @pytest.fixture(scope="session")
 def port(pytestconfig):
-    '''Load --port command-line arg if set'''
+    """Load --port command-line arg if set"""
     return pytestconfig.getoption("port")
 
 
@@ -32,9 +36,7 @@ def instance(port):
 
         return g
     except Exception:
-        assert (
-            False
-        ), f"AllSpice Hub could not load. Is there: \
+        assert False, f"AllSpice Hub could not load. Is there: \
                 - an Instance running at http://localhost:{port} \
                 - a Token at .token \
                     ?"
@@ -55,8 +57,9 @@ def _setup_for_generation(instance, test_name):
 
 def test_bom_generation(request, instance):
     _setup_for_generation(instance, request.node.name)
-    repo = instance.get_repository(instance.get_user().username,
-                                   "-".join([test_repo, request.node.name]))
+    repo = instance.get_repository(
+        instance.get_user().username, "-".join([test_repo, request.node.name])
+    )
     attributes_mapping = AttributesMapping(
         description=["PART DESCRIPTION"],
         designator=["Designator"],
@@ -78,7 +81,7 @@ def test_bom_generation(request, instance):
     # We have to do this manually because of how csv.DictWriter works.
     for item in bom:
         entry_as_dict = {}
-        for (key, value) in dataclasses.asdict(item).items():
+        for key, value in dataclasses.asdict(item).items():
             entry_as_dict[key] = str(value) if value is not None else ""
         bom_as_dicts.append(entry_as_dict)
 
@@ -90,8 +93,9 @@ def test_bom_generation(request, instance):
 
 def test_bom_generation_with_odd_line_endings(request, instance):
     _setup_for_generation(instance, request.node.name)
-    repo = instance.get_repository(instance.get_user().username,
-                                   "-".join([test_repo, request.node.name]))
+    repo = instance.get_repository(
+        instance.get_user().username, "-".join([test_repo, request.node.name])
+    )
     # We hard-code a ref so that this test is reproducible.
     ref = "95719adde8107958bf40467ee092c45b6ddaba00"
     attributes_mapping = AttributesMapping(
@@ -114,12 +118,7 @@ def test_bom_generation_with_odd_line_endings(request, instance):
     prjpcb_content = base64.b64decode(encoded_content).decode("utf-8")
     new_prjpcb_content = prjpcb_content.replace("\r\n", "\n\r")
     new_content_econded = base64.b64encode(new_prjpcb_content.encode("utf-8")).decode("utf-8")
-    repo.change_file(
-        "Archimajor.PrjPcb",
-        original_prjpcb_sha,
-        new_content_econded,
-        {"branch": ref}
-    )
+    repo.change_file("Archimajor.PrjPcb", original_prjpcb_sha, new_content_econded, {"branch": ref})
 
     # Sanity check that the file was changed.
     prjpcb_content_now = _get_file_content(repo, "Archimajor.PrjPcb", ref)
@@ -141,7 +140,7 @@ def test_bom_generation_with_odd_line_endings(request, instance):
     # We have to do this manually because of how csv.DictWriter works.
     for item in bom:
         entry_as_dict = {}
-        for (key, value) in dataclasses.asdict(item).items():
+        for key, value in dataclasses.asdict(item).items():
             entry_as_dict[key] = str(value) if value is not None else ""
         bom_as_dicts.append(entry_as_dict)
 
@@ -153,8 +152,9 @@ def test_bom_generation_with_odd_line_endings(request, instance):
 
 def test_netlist_generation(request, instance):
     _setup_for_generation(instance, request.node.name)
-    repo = instance.get_repository(instance.get_user().username,
-                                   "-".join([test_repo, request.node.name]))
+    repo = instance.get_repository(
+        instance.get_user().username, "-".join([test_repo, request.node.name])
+    )
     netlist = generate_netlist(
         instance,
         repo,


### PR DESCRIPTION
This PR removes autopep8 and uses ruff instead for formatting checking in CI. We are already using ruff for linting, and it comes with a formatter, so we don't need to manage autopep8 for formatting. This change does lead to different formatting because ruff's is black-compatible.