### PR TITLE
Add API method to get the raw binary content of a single file

### DIFF
--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -908,7 +908,7 @@ class Repository(ApiObject):
 
     def get_raw_file(
         self,
-        content: Union[str, Content],
+        file_path: str,
         ref: Optional[Ref] = None,
     ) -> bytes:
         """
@@ -921,15 +921,12 @@ class Repository(ApiObject):
 
         See https://hub.allspice.io/api/swagger#/repository/repoGetRawFile
 
-        :param content: The path to the file to get. This can be a string or a
-            Content object.
+        :param file_path: The path to the file to get.
         :param ref: The branch or commit to get the file from.  If not provided,
             the default branch is used.
         """
 
-        if isinstance(content, Content):
-            content = content.path
-        url = f"/repos/{self.owner.username}/{self.name}/raw/{content}"
+        url = f"/repos/{self.owner.username}/{self.name}/raw/{file_path}"
         params = Util.data_params_for_ref(ref)
         return self.allspice_client.requests_get_raw(url, params=params)
 

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -906,6 +906,28 @@ class Repository(ApiObject):
                 for f in self.allspice_client.requests_get(url, data)
             ]
 
+    def get_raw_file(
+        self,
+        content: Union[str, Content],
+        ref: Optional[Ref] = None,
+    ) -> bytes:
+        """
+        Get the raw, binary data of a single file.
+
+        See https://hub.allspice.io/api/swagger#/repository/repoGetRawFile
+
+        :param content: The path to the file to get. This can be a string or a
+            Content object.
+        :param ref: The branch or commit to get the file from.  If not provided,
+            the default branch is used.
+        """
+
+        if isinstance(content, Content):
+            content = content.path
+        url = f"/repos/{self.owner.name}/{self.name}/raw/{content}"
+        params = Util.data_params_for_ref(ref)
+        return self.allspice_client.requests_get_raw(url, params=params)
+
     def get_generated_json(self, content: Union[Content, str], ref: Optional[Ref] = None) -> dict:
         """
         Get the json blob for a cad file if it exists, otherwise enqueue

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -914,6 +914,11 @@ class Repository(ApiObject):
         """
         Get the raw, binary data of a single file.
 
+        Note: if the file you are requesting is a text file, you might want to
+        use .decode() on the result to get a string. For example:
+
+            content = repo.get_raw_file("file.txt").decode("utf-8")
+
         See https://hub.allspice.io/api/swagger#/repository/repoGetRawFile
 
         :param content: The path to the file to get. This can be a string or a
@@ -924,7 +929,7 @@ class Repository(ApiObject):
 
         if isinstance(content, Content):
             content = content.path
-        url = f"/repos/{self.owner.name}/{self.name}/raw/{content}"
+        url = f"/repos/{self.owner.username}/{self.name}/raw/{content}"
         params = Util.data_params_for_ref(ref)
         return self.allspice_client.requests_get_raw(url, params=params)
 

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import base64
 
 from dataclasses import dataclass
 import re

--- a/allspice/utils/bom_generation.py
+++ b/allspice/utils/bom_generation.py
@@ -125,7 +125,7 @@ def generate_bom_for_altium(
     )
     allspice_client.logger.info(f"Fetching {prjpcb_file=} and {pcbdoc_file=}")
 
-    prjpcb_file = _get_file_content(repository, prjpcb_file, ref)
+    prjpcb_file = repository.get_raw_file(prjpcb_file, ref=ref).decode("utf-8")
     schdoc_files_in_proj = {x for x in _extract_schdoc_list_from_prjpcb(prjpcb_file)}
 
     allspice_client.logger.info("Found %d SchDoc files", len(schdoc_files_in_proj))
@@ -163,20 +163,6 @@ def _find_first_matching_key(
             return attributes[alternative]["text"]
 
     return None
-
-
-def _get_file_content(repo, file_path, ref) -> str:
-    """
-    Get the content of a file in a repo on a branch.
-    """
-
-    files_in_repo = repo.get_git_content(ref=ref)
-    file = next((x for x in files_in_repo if x.path == file_path), None)
-    if not file:
-        raise ValueError(f"File {file_path} not found in repo {repo.name} at ref {ref.name}")
-
-    content = repo.get_file_content(file, ref=ref)
-    return base64.b64decode(content).decode("utf-8")
 
 
 def _extract_schdoc_list_from_prjpcb(prjpcb_file_content) -> list[str]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -308,17 +308,6 @@ def test_get_raw_file(instance):
     assert "descr" in str(readme_content)
 
 
-def test_get_raw_file_with_content(instance):
-    org = Organization.request(instance, test_org)
-    repo = org.get_repository(test_repo)
-    content = repo.get_git_content()
-    readmes = [c for c in content if c.name == "README.md"]
-    assert len(readmes) > 0
-    readme_content = repo.get_raw_file(readmes[0])
-    assert len(readme_content) > 0
-    assert "descr" in str(readme_content)
-
-
 def test_create_file(instance):
     TESTFILE_CONENTE = "TestStringFileContent"
     TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, "utf-8"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,6 +300,25 @@ def test_list_files_and_content(instance):
     assert "descr" in str(base64.b64decode(readme_content))
 
 
+def test_get_raw_file(instance):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    readme_content = repo.get_raw_file("README.md")
+    assert len(readme_content) > 0
+    assert "descr" in str(readme_content)
+
+
+def test_get_raw_file_with_content(instance):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    content = repo.get_git_content()
+    readmes = [c for c in content if c.name == "README.md"]
+    assert len(readmes) > 0
+    readme_content = repo.get_raw_file(readmes[0])
+    assert len(readme_content) > 0
+    assert "descr" in str(readme_content)
+
+
 def test_create_file(instance):
     TESTFILE_CONENTE = "TestStringFileContent"
     TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, "utf-8"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,6 @@ from allspice import AllSpice
 from allspice.utils.bom_generation import (
     AttributesMapping,
     generate_bom_for_altium,
-    _get_file_content,
 )
 from allspice.utils.netlist_generation import generate_netlist
 
@@ -114,14 +113,13 @@ def test_bom_generation_with_odd_line_endings(request, instance):
     assert prjpcb_file is not None
 
     original_prjpcb_sha = prjpcb_file.sha
-    encoded_content = repo.get_file_content(prjpcb_file, ref=ref)
-    prjpcb_content = base64.b64decode(encoded_content).decode("utf-8")
+    prjpcb_content = repo.get_raw_file(prjpcb_file, ref=ref).decode("utf-8")
     new_prjpcb_content = prjpcb_content.replace("\r\n", "\n\r")
     new_content_econded = base64.b64encode(new_prjpcb_content.encode("utf-8")).decode("utf-8")
     repo.change_file("Archimajor.PrjPcb", original_prjpcb_sha, new_content_econded, {"branch": ref})
 
     # Sanity check that the file was changed.
-    prjpcb_content_now = _get_file_content(repo, "Archimajor.PrjPcb", ref)
+    prjpcb_content_now = repo.get_raw_file("Archimajor.PrjPcb", ref=ref).decode("utf-8")
     assert prjpcb_content_now != prjpcb_content
 
     bom = generate_bom_for_altium(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,7 +113,7 @@ def test_bom_generation_with_odd_line_endings(request, instance):
     assert prjpcb_file is not None
 
     original_prjpcb_sha = prjpcb_file.sha
-    prjpcb_content = repo.get_raw_file(prjpcb_file, ref=ref).decode("utf-8")
+    prjpcb_content = repo.get_raw_file(prjpcb_file.path, ref=ref).decode("utf-8")
     new_prjpcb_content = prjpcb_content.replace("\r\n", "\n\r")
     new_content_econded = base64.b64encode(new_prjpcb_content.encode("utf-8")).decode("utf-8")
     repo.change_file("Archimajor.PrjPcb", original_prjpcb_sha, new_content_econded, {"branch": ref})


### PR DESCRIPTION
Closes #61. This endpoint method is simpler to use and doesn't require a base64 round trip when fetching a single file with a known path. This PR also removes the makeshift `_get_file_content` method used in BOM generation.