### PR TITLE
Add method to download release asset

### DIFF
--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -1054,8 +1054,8 @@ class Repository(ApiObject):
     def create_release(
         self,
         tag_name: str,
-        name: Optional[str],
-        body: Optional[str],
+        name: Optional[str] = None,
+        body: Optional[str] = None,
         draft: bool = False,
     ):
         """

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -1839,16 +1839,41 @@ class ReleaseAsset(ApiObject):
         """
         Download the raw, binary data of this asset.
 
-        Note: if the file you are requesting is a text file, you might want to
+        Note 1: if the file you are requesting is a text file, you might want to
         use .decode() on the result to get a string. For example:
 
             asset.download().decode("utf-8")
+
+        Note 2: this method will store the entire file in memory. If you are
+        downloading a large file, you might want to use download_to_file instead.
         """
 
         return self.allspice_client.requests.get(
             self.browser_download_url,
             headers=self.allspice_client.headers,
         ).content
+
+    def download_to_file(self, io: IO):
+        """
+        Download the raw, binary data of this asset to a file-like object.
+
+        Example:
+
+            with open("my_file.zip", "wb") as f:
+                asset.download_to_file(f)
+
+        :param io: The file-like object to write the data to.
+        """
+
+        response = self.allspice_client.requests.get(
+            self.browser_download_url,
+            headers=self.allspice_client.headers,
+            stream=True,
+        )
+        # 4kb chunks
+        for chunk in response.iter_content(chunk_size=4096):
+            if chunk:
+                io.write(chunk)
 
     def delete(self):
         args = {

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -1835,6 +1835,21 @@ class ReleaseAsset(ApiObject):
         }
         self._commit(args)
 
+    def download(self) -> bytes:
+        """
+        Download the raw, binary data of this asset.
+
+        Note: if the file you are requesting is a text file, you might want to
+        use .decode() on the result to get a string. For example:
+
+            asset.download().decode("utf-8")
+        """
+
+        return self.allspice_client.requests.get(
+            self.browser_download_url,
+            headers=self.allspice_client.headers,
+        ).content
+
     def delete(self):
         args = {
             "owner": self.release.repo.owner.name,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -704,6 +704,9 @@ def test_get_design_review_comments(instance):
 def test_repo_create_release(instance):
     org = Organization.request(instance, test_org)
     repo = Repository.request(instance, org.username, test_repo)
+    # Just a tag should be enough.
+    release = repo.create_release("v0.0.1")
+    assert release.tag_name == "v0.0.1"
     release = repo.create_release("v0.1.0", "v0.1.0 release", "release with new tag")
     assert release.tag_name == "v0.1.0"
     assert release.name == "v0.1.0 release"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -777,6 +777,15 @@ def test_get_release_assets(instance):
     assert release.assets[0].name == "requirements.txt"
 
 
+def test_download_release_asset(instance):
+    org = Organization.request(instance, test_org)
+    repo = Repository.request(instance, org.username, test_repo)
+    release = repo.get_latest_release()
+    asset = release.assets[0]
+    data = asset.download()
+    assert data == open("requirements.txt", "rb").read()
+
+
 def test_delete_release_asset(instance):
     org = Organization.request(instance, test_org)
     repo = Repository.request(instance, org.username, test_repo)
@@ -790,8 +799,9 @@ def test_delete_release(instance):
     org = Organization.request(instance, test_org)
     repo = Repository.request(instance, org.username, test_repo)
     release = repo.get_latest_release()
+    old_releases = repo.get_releases()
     release.delete()
-    assert len(repo.get_releases()) == 0
+    assert len(repo.get_releases()) == len(old_releases) - 1
 
 
 def test_get_repo_archive(instance):


### PR DESCRIPTION
Closes #75. This also changes the `repo.create_release` method to make arguments that should've been optional actually optional. This was an oversight in the original releases PR.