### PR TITLE
Prep for v2.5 release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,31 +3,28 @@ name: Publish py-allspice 📦 to PyPI
 on:
   push:
     tags:
-     - 'v*.*'
+      - "v*.*"
 
 jobs:
   build-n-publish:
     name: Build and deploy py-allspice 📦 to PyPI
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install pypa/setuptools
-      run: >-
-        python -m pip install build
-    - name: Extract tag name
-      id: tag
-      run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3 | sed -e 's/v//1')
-    - name: Update version in setup.py
-      run: >-
-        sed -i "s/{{\s*VERSION_PLACEHOLDER\s*}}/${{ steps.tag.outputs.TAG_NAME }}/g" setup.py
-    - name: Build a wheel
-      run: >-
-        python -m build
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install pypa/setuptools
+        run: >-
+          python -m pip install build
+      - name: Extract tag name
+        id: tag
+        run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3 | sed -e 's/v//1')
+      - name: Build a wheel
+        run: >-
+          python -m build
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_DEPLOY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           ruff format --diff .
       - name: Lint with ruff
         run: |
-          ruff --target-version=py310 .
+          ruff check --target-version=py310 .
       - name: Set up allspice_hub
         run: |
           # The only way to create a user is to either use the CLI or the web
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pytest
 
-# We might want to consider moving this to a new workflow if we add addition test jobs
+  # We might want to consider moving this to a new workflow if we add addition test jobs
   notifications:
     name: Notifications
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ need to change your scripts to update to this version.
 
   This is better than using `repo.get_file_contents` in almost all cases.
 
+- Add APIs to work with commit statuses by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/74
+
+  Commit statuses are the status of checks run via actions on commits. You can
+  use the new `Commit.get_status` and `Repository.create_commit_status` methods
+  to work with them.
+
 ### Internals
 
 - CI: Add cron by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/52

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## v2.5.0
+
+This is a minor version bump. Only new functionality was added, and you may not
+need to change your scripts to update to this version.
+
+### New Features and Bugfixes
+
+- Broaden newline regex in Alitum BOM generation by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/62
+
+  This fixes a reported issue with some Altium PrjPcb files.
+
+- Add APIs to work with releases and their assets by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/73
+
+  Now you can fetch a repository's releases using:
+
+  ```py
+  releases = repo.get_releases()
+
+  # or
+
+  release = repo.get_latest_release()
+
+  # or
+
+  release = repo.get_release_by_tag("v1.1")
+
+  # and even
+
+  release = repo.create_release("v1.2")
+  ```
+
+  And add attachments to the releases:
+
+  ```py
+  release = repo.get_latest_release()
+  release.create_asset(gerber_file)
+  ```
+
+  See the `allspice.Release` class for more details.
+
+- Add API method to get the raw binary content of a single file by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/77
+
+  Example:
+
+  ```py
+  file_content = repo.get_raw_file("README.md").decode("utf-8")
+  ```
+
+  This is better than using `repo.get_file_contents` in almost all cases.
+
+### Internals
+
+- CI: Add cron by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/52
+- added flake.nix by @McRaeAlex in https://github.com/AllSpiceIO/py-allspice/pull/57
+- doc: Update README to fix broken example link by @jtran in https://github.com/AllSpiceIO/py-allspice/pull/59
+- Remove autopep8 completely by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/67
+
+### New Contributors
+
+- @McRaeAlex made their first contribution in https://github.com/AllSpiceIO/py-allspice/pull/57
+- @jtran made their first contribution in https://github.com/AllSpiceIO/py-allspice/pull/59
+
+**Full Changelog**: https://github.com/AllSpiceIO/py-allspice/compare/v2.4.0...v2.5.0
+
+## v2.4.0
+
+### What's Changed
+
+- CI Fixes for Gitea 1.20 by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/48
+- Add generate netlist routine by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/50
+- Add error message for component link error by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/54
+- Add delete_file routine by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/56
+
+### New Contributors
+
+- @kdumontnu made their first contribution in https://github.com/AllSpiceIO/py-allspice/pull/48
+
+**Full Changelog**: https://github.com/AllSpiceIO/py-allspice/compare/v2.3.1...v2.4.0
+
 ## v2.3.1
 
 This is a patch release. You should be able to update to this version without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ need to change your scripts to update to this version.
 
   ```py
   release = repo.get_latest_release()
-  release.create_asset(gerber_file)
+  asset = release.create_asset(gerber_file)
+  asset.download() # Download the file from the server!
   ```
 
   See the `allspice.Release` class for more details.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as readme_file:
 
 setup_args = dict(
     name="py-allspice",
-    version="2.4.1-dev",
+    version="2.5.0",
     description="A python wrapper for the AllSpice Hub API",
     long_description_content_type="text/markdown",
     long_description=README,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -833,7 +833,7 @@ def test_get_commit_combined_status(instance):
     commit = repo.get_commits()[0]
     status = commit.get_status()
     assert status is not None
-    assert status.state == CommitStatusState.ERROR
+    assert status.state == CommitStatusState.FAILURE
 
 
 def test_get_commit_status_from(instance):


### PR DESCRIPTION
- Removes a deprecation warning from using ruff in the test workflow
- Removes dynamic insertion of a version into setup.py at tag time.
- Formatting changes in both workflow files
- Adds v2.5 changes to the changelog.

~~Stacked on #78 since the changelog assumes the optional args fix there.~~