### PR TITLE
Remove PCB from BOM generation

### DIFF
--- a/examples/generate_bom/generate_bom.py
+++ b/examples/generate_bom/generate_bom.py
@@ -24,12 +24,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="generate_bom", description="Generate a BOM from a PrjPcb file."
     )
-    parser.add_argument("repository", help="The repo containing the project")
-    parser.add_argument("prjpcb_file", help="The path to the PrjPcb file in the source repo.")
     parser.add_argument(
-        "pcb_file",
-        help="The path to the PCB file in the source repo.",
+        "repository", help="The repo containing the project in the form 'owner/repo'"
     )
+    parser.add_argument("prjpcb_file", help="The path to the PrjPcb file in the source repo.")
     parser.add_argument(
         "--source_ref",
         help="The git reference the netlist should be generated for (eg. branch name, tag name, commit SHA). Defaults to main.",
@@ -65,7 +63,6 @@ if __name__ == "__main__":
     repo_owner, repo_name = args.repository.split("/")
     repository = allspice.get_repository(repo_owner, repo_name)
     prjpcb_file = args.prjpcb_file
-    pcb_file = args.pcb_file
 
     print("Generating BOM...", file=sys.stderr)
 
@@ -73,7 +70,6 @@ if __name__ == "__main__":
         allspice,
         repository,
         prjpcb_file,
-        pcb_file,
         attributes_mapper,
         args.source_ref,
     )

--- a/tests/data/archimajor_bom_expected.csv
+++ b/tests/data/archimajor_bom_expected.csv
@@ -1,108 +1,108 @@
 description,manufacturer,part_number,designators,quantity
-"1k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-071KL,"['R198', 'R197', 'R74', 'R76', 'R19', 'R23', 'R191', 'R193', 'R72', 'R79', 'R188', 'R187', 'R177', 'R175', 'R176', 'R186', 'R174', 'R189', 'R34', 'R36', 'R40', 'R41', 'R71', 'R108H', 'R108G', 'R108F', 'R108E', 'R108D', 'R108C', 'R108B', 'R108A', 'R33', 'R102', 'R152']",34
-"MULTICOMP  2211S-03G  Board-To-Board Connector, 2.54 mm, 3 Contacts, Header, 2211S Series, Through Hole, 1 Rows",Multicomp,2211S-03G,['J24'],1
-,Samsung,CL03A104KQ3NNNC,"['C207', 'C204', 'C206', 'C215', 'C205', 'C208', 'C217', 'C2', 'C106', 'C78', 'C91', 'C100', 'C105', 'C67', 'C149H', 'C149G', 'C149F', 'C149E', 'C149D', 'C149C', 'C149B', 'C149A', 'C62A', 'C62B', 'C62C', 'C62D', 'C62E', 'C60A', 'C60B', 'C60C', 'C60D', 'C60E']",32
-10000pF ±5% 50V Ceramic Capacitor X7R 0402 (1005 Metric),Murata,GRM155R71H103JA88D,"['C158', 'C157', 'C84', 'C160', 'C216', 'C214', 'C159', 'C86', 'C40', 'C171', 'C71', 'C30A', 'C30B', 'C30C', 'C30D', 'C30E', 'C12A', 'C12B', 'C12C', 'C12D', 'C12E', 'C77', 'C43']",23
-,,NOTAPART-Testpoint,"['TP19', 'TP130', 'TP80', 'TP81', 'TP25', 'TP131', 'TP82', 'TP67', 'TP77', 'TP52', 'TP128', 'TP76', 'TP13', 'TP129', 'TP21', 'TP16', 'TP74', 'TP53', 'TP54', 'TP14', 'TP50', 'TP49', 'TP56', 'TP20', 'TP26', 'TP27', 'TP15', 'TP22', 'TP29', 'TP78', 'TP75', 'TP37', 'TP35', 'TP58', 'TP59', 'TP66', 'TP64', 'TP65', 'TP62', 'TP40', 'TP38', 'TP39', 'TP63', 'TP12A', 'TP12H', 'TP12G', 'TP12F', 'TP12E', 'TP12D', 'TP12C', 'TP12B', 'TP41A', 'TP41H', 'TP41G', 'TP41F', 'TP41E', 'TP41D', 'TP41C', 'TP41B', 'TP34A', 'TP34H', 'TP34G', 'TP34F', 'TP34E', 'TP34D', 'TP34C', 'TP34B', 'TP3A', 'TP3H', 'TP3G', 'TP3F', 'TP3E', 'TP3D', 'TP3C', 'TP3B', 'TP33', 'TP79', 'TP43', 'TP48', 'TP47', 'TP44', 'TP36', 'TP46', 'TP51', 'TP107', 'TP106', 'TP101', 'TP9', 'TP108', 'TP10', 'TP23A', 'TP23B', 'TP23C', 'TP23D', 'TP23E', 'TP24A', 'TP24B', 'TP24C', 'TP24D', 'TP24E', 'TP11A', 'TP11B', 'TP11C', 'TP11D', 'TP11E', 'TP60', 'TP31', 'TP30', 'TP61', 'TP6', 'TP5', 'TP32', 'TP55']",113
-"3 Positions Header, Shrouded Connector 0.100 (2.54mm) Through Hole Gold",Molex,0705430002,"['J9', 'J5', 'J32', 'J33', 'J6', 'J7', 'J11', 'J10', 'J29', 'J31', 'J30', 'J22']",12
-TVS DIODE 3.3VWM SOD923,On Semi,ESD9X3.3ST5G,"['D35', 'D34', 'D32', 'D59', 'D13', 'D58', 'D3', 'D33', 'D42', 'D71', 'D65', 'D67', 'D44', 'D68', 'D66', 'D64', 'D72', 'D69', 'D1', 'D73']",20
-"100k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Samsung,RC1005F104CS,"['R35', 'R22', 'R190', 'R75', 'R192', 'R73', 'R63', 'R78', 'R31', 'R38', 'R37', 'R158', 'R58', 'R51']",14
-Diode Schottky 30V 200mA (DC) Surface Mount SOD-523,Diodes Incorporated,BAT54WX-TP,"['D57', 'D54', 'D50', 'D55', 'D52', 'D56', 'D53', 'D51', 'D40', 'D63', 'D74', 'D60', 'D62', 'D75', 'D61', 'D77', 'D70', 'D30', 'D5', 'D41', 'D76', 'D31', 'D20H', 'D20G', 'D20F', 'D20E', 'D20D', 'D20C', 'D20B', 'D20A', 'D19H', 'D19G', 'D19F', 'D19E', 'D19D', 'D19C', 'D19B', 'D19A', 'D12H', 'D12G', 'D12F', 'D12E', 'D12D', 'D12C', 'D12B', 'D12A', 'D36', 'D38', 'D37', 'D28', 'D29', 'D39']",52
-"10k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0710KP,"['R183', 'R101', 'R171', 'R14', 'R182', 'R15', 'R96', 'R12', 'R95', 'R67', 'R68', 'R85', 'R100', 'R70', 'R69', 'R65', 'R64', 'R66', 'R97', 'R30', 'R8', 'R54', 'R39', 'R29', 'R6', 'R9', 'R7', 'R119', 'R155', 'R11', 'R56']",31
-,Yageo,RC0402FR-071K8L,"['R185', 'R173', 'R184', 'R172']",4
-"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)",Texas Instruments,SN74AHCT125RGYR,[],0
-"100 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-07100RL,"['R98', 'R99', 'R181', 'R180', 'R142', 'R139', 'R138', 'R153', 'R140', 'R120', 'R136', 'R159', 'R109', 'R135', 'R143', 'R145', 'R144', 'R137', 'R141', 'R133', 'R160', 'R114', 'R161', 'R134', 'R21', 'R53', 'R20', 'R25', 'R149']",29
-,Murata,GRM155R71C104KA88D,"['C213', 'C156', 'C212', 'C155', 'C92', 'C44', 'C68', 'C166', 'C164', 'C81', 'C167', 'C80', 'C46', 'C45', 'C66', 'C51', 'C56', 'C73', 'C54', 'C82', 'C165', 'C65', 'C63', 'C69', 'C52', 'C21', 'C22', 'C19', 'C31', 'C20', 'C201', 'C26', 'C200', 'C162', 'C103', 'C161', 'C76', 'C33', 'C28', 'C29', 'C169', 'C39']",42
-,,,"['TP2', 'TP8', 'TP1', 'TP18', 'TP17', 'P2H', 'P2G', 'P2F', 'P2E', 'P2D', 'P2C', 'P2A', 'P2B', 'TP69', 'TP4', 'TP7']",16
-,On Semi,NCV8402ADDR2G,[],0
-,,DNI-C0603TBD,"['C209', 'C153', 'C154', 'C211', 'C9', 'C10', 'C8', 'C11', 'C27', 'C50']",10
-,Dialight,5988110107F,"['LED3', 'LED2', 'LED1', 'LED4', 'D24', 'D18', 'D16', 'D17', 'D9']",9
-TBD,TBD,TBD,"['C101', 'C90', 'C79', 'C104', 'C64', 'C83', 'C89', 'C102', 'C75', 'C74', 'C87', 'C88', 'C85', 'C3']",14
-,Vishay Dale,CRCW040247R0FKEDC,"['R84', 'R13', 'R4', 'R93', 'R94', 'R59', 'R89', 'R3', 'R32', 'R163H', 'R163G', 'R163F', 'R163E', 'R163D', 'R163C', 'R163B', 'R163A', 'R116H', 'R116G', 'R116D', 'R116F', 'R116E', 'R116C', 'R116B', 'R116A', 'R86H', 'R86G', 'R86F', 'R86E', 'R86D', 'R86C', 'R86B', 'R86A', 'R170H', 'R170G', 'R170F', 'R170E', 'R170D', 'R170C', 'R170B', 'R170A', 'R168H', 'R168G', 'R168F', 'R168E', 'R168D', 'R168C', 'R168B', 'R168A', 'R88A', 'R88B', 'R88C', 'R88E', 'R88D']",54
-Tactile Switches R/A SEALED TACT SWITCH,TE,1571610-2,['S1'],1
-"10 (8 + 2) Position Card Connector Secure Digital - microSD™ Surface Mount, Right Angle Gold",Molex,0475710001,['J18'],1
-"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)",TI,SN74LVC125ARGYR,"['U16', 'U17']",2
-VARISTOR 6.8V 10A 0201,TDK,AVRM0603C6R8NT101N,"['RV4', 'RV1', 'RV2', 'RV3', 'RV5H', 'RV5G', 'RV5F', 'RV5E', 'RV5D', 'RV5C', 'RV5B', 'RV5A', 'RV7H', 'RV7G', 'RV7F', 'RV7E', 'RV7D', 'RV7C', 'RV7B', 'RV7A', 'RV6H', 'RV6F', 'RV6E', 'RV6D', 'RV6C', 'RV6B', 'RV6G', 'RV6A']",28
-,,DNI-R0402TBD,"['R60', 'R17H', 'R17F', 'R17E', 'R17D', 'R17C', 'R17B', 'R17G', 'R17A']",9
-Clock Fanout Buffer (Distribution) IC 1:4  8-XFDFN,Nexperia,74AVC9112GTX,['U14'],1
-"24 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0724RL,"['R82', 'R83', 'R77', 'R43', 'R42', 'R48', 'R46', 'R45', 'R47']",9
-CAP CER 10UF 6.3V 10% JB 0603,TDK,C1608JB0J106K080AB,"['C53', 'C70', 'C55', 'C37', 'C72', 'C57']",6
-FERRITE BEAD 120 OHM 0603 1LN,Samsung,CIS10P121AC,"['FB28', 'FB27', 'FB30', 'FB26', 'FB29']",5
-TVS DIODE 5V 9V SOD923,Toshiba,"DF2S6.8FS,L3M",['D45'],1
-Tactile Switch SPST-NO Top Actuated Surface Mount,C&K,KMR741NG ULC LFS,['S2'],1
-ARM® Cortex®-M3 SAM3X Microcontroller IC 32-Bit 84MHz 512KB (512K x 8) FLASH 144-LQFP (20x20),Atmel,ATSAM3X8EA-AU,[],0
-"10 Positions Header, Unshrouded Connector 0.050 (1.27mm) Surface Mount Gold",Amphenol FCI,20021121-00010C4LF,['J4'],1
-10 Positions Header Connector 0.100 (2.54mm) Through Hole Gold,On Shore,302-S101,"['J12', 'J28', 'J13']",3
-Yellow 593nm LED Indication - Discrete 2V 0805 (2012 Metric),Dialight,5988140107F,['D25'],1
-"Board-To-Board Connector, 2.54 mm, 24 Contacts, Header, 2213S Series, Through Hole, 2 Rows",Multicomp,2213S-24G,['J20'],1
-IC FLASH 16M SPI 104MHZ 8SOIC,Adesto,AT25SF161-SSHD-T,['U12'],1
-"10 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0710RL,"['R24', 'R52', 'R27', 'R55', 'R167G', 'R167H', 'R167F', 'R167E', 'R167D', 'R167C', 'R167B', 'R167A', 'R111H', 'R111G', 'R111F', 'R111E', 'R111D', 'R111C', 'R111B', 'R111A', 'R166H', 'R166G', 'R166F', 'R166E', 'R166D', 'R166C', 'R166B', 'R166A', 'R112H', 'R112G', 'R112F', 'R112E', 'R112D', 'R112C', 'R112B', 'R112A', 'R164H', 'R164G', 'R164F', 'R164E', 'R164D', 'R164C', 'R164B', 'R164A', 'R110H', 'R110G', 'R110F', 'R110E', 'R110D', 'R110C', 'R110B', 'R110A', 'R113H', 'R113G', 'R113F', 'R113E', 'R113D', 'R113C', 'R113B', 'R113A', 'R165H', 'R165G', 'R165F', 'R165E', 'R165D', 'R165C', 'R165B', 'R165A']",68
+"10 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0710RL,"['R24', 'R52', 'R27', 'R55', 'R167A', 'R167B', 'R167C', 'R167D', 'R167E', 'R167F', 'R167G', 'R167H', 'R111A', 'R111B', 'R111C', 'R111D', 'R111E', 'R111F', 'R111G', 'R111H', 'R166A', 'R166B', 'R166C', 'R166D', 'R166E', 'R166F', 'R166G', 'R166H', 'R112A', 'R112B', 'R112C', 'R112D', 'R112E', 'R112F', 'R112G', 'R112H', 'R164A', 'R164B', 'R164C', 'R164D', 'R164E', 'R164F', 'R164G', 'R164H', 'R110A', 'R110B', 'R110C', 'R110D', 'R110E', 'R110F', 'R110G', 'R110H', 'R113A', 'R113B', 'R113C', 'R113D', 'R113E', 'R113F', 'R113G', 'R113H', 'R165A', 'R165B', 'R165C', 'R165D', 'R165E', 'R165F', 'R165G', 'R165H']",68
+0.10µF ±10% 16V Ceramic Capacitor X7R 0402 (1005 Metric),Murata,GRM155R71C104KA88D,"['C21', 'C22', 'C19', 'C31', 'C20', 'C213', 'C156', 'C212', 'C155', 'C92', 'C76', 'C33', 'C28', 'C29', 'C169', 'C39', 'C201', 'C26', 'C200', 'C44', 'C68', 'C166', 'C164', 'C81', 'C167', 'C80', 'C46', 'C45', 'C66', 'C51', 'C56', 'C73', 'C54', 'C82', 'C165', 'C65', 'C63', 'C69', 'C52', 'C162', 'C103', 'C161']",42
+None,None,NOTAPART-Testpoint,"['TP37', 'TP35', 'TP58', 'TP59', 'TP66', 'TP64', 'TP65', 'TP62', 'TP40', 'TP38', 'TP39', 'TP63', 'TP23A', 'TP23B', 'TP23C', 'TP23D', 'TP23E', 'TP24A', 'TP24B', 'TP24C', 'TP24D', 'TP24E', 'TP11A', 'TP11B', 'TP11C', 'TP11D', 'TP11E', 'TP12A', 'TP12B', 'TP12C', 'TP12D', 'TP12E', 'TP12F', 'TP12G', 'TP12H', 'TP41A', 'TP41B', 'TP41C', 'TP41D', 'TP41E', 'TP41F', 'TP41G', 'TP41H', 'TP34A', 'TP34B', 'TP34C', 'TP34D', 'TP34E', 'TP34F', 'TP34G', 'TP34H', 'TP3A', 'TP3B', 'TP3C', 'TP3D', 'TP3E', 'TP3F', 'TP3G', 'TP3H', 'TP60', 'TP31', 'TP30', 'TP61', 'TP6', 'TP5', 'TP32', 'TP55', 'TP19', 'TP130', 'TP80', 'TP81', 'TP25', 'TP131', 'TP82', 'TP67', 'TP33', 'TP79', 'TP43', 'TP48', 'TP47', 'TP44', 'TP36', 'TP46', 'TP51', 'TP77', 'TP52', 'TP128', 'TP76', 'TP13', 'TP129', 'TP21', 'TP16', 'TP74', 'TP53', 'TP54', 'TP14', 'TP50', 'TP49', 'TP56', 'TP20', 'TP26', 'TP27', 'TP15', 'TP22', 'TP29', 'TP78', 'TP75', 'TP511', 'TP107', 'TP510', 'TP106', 'TP101', 'TP9', 'TP108', 'TP10', 'TP502']",116
+"100 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-07100RL,"['R21', 'R53', 'R20', 'R25', 'R98', 'R99', 'R181', 'R180', 'R149', 'R142', 'R139', 'R138', 'R153', 'R140', 'R120', 'R136', 'R159', 'R109', 'R135', 'R143', 'R145', 'R144', 'R137', 'R141', 'R133', 'R160', 'R114', 'R161', 'R134']",29
+"10k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0710KP,"['R30', 'R8', 'R54', 'R39', 'R29', 'R6', 'R9', 'R7', 'R183', 'R101', 'R171', 'R14', 'R182', 'R15', 'R96', 'R12', 'R119', 'R155', 'R11', 'R56', 'R95', 'R67', 'R68', 'R85', 'R100', 'R70', 'R69', 'R65', 'R64', 'R66', 'R97']",31
 TVS DIODE 30VWM SOD323,Rohm,RSB39VTE-17,"['D14', 'D10', 'D11', 'D4', 'D26']",5
 Diode Schottky 100V 3A Surface Mount DO-214AC (HSMA),MCC,SK310A,"['D7', 'D15', 'D8', 'D6']",4
+None,None,DNI-C0603TBD,"['C9', 'C10', 'C8', 'C11', 'C209', 'C153', 'C154', 'C211', 'C27', 'C50']",10
 MOSFET N-CH 40V 100A 8VSON,TI,CSD18503Q5A,"['Q1', 'Q3', 'Q2', 'Q4']",4
 Low-Side Gate Driver IC Non-Inverting SOT-26,Diodes Incorporated,ZXGD3009E6TA,"['U4', 'U7', 'U5', 'U3']",4
-,Molex,0430450612,['J1'],1
-0.10µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),Kemet,C0603C104K5RACTU,"['C122H', 'C122G', 'C122F', 'C122E', 'C122D', 'C122C', 'C122B', 'C122A', 'C121H', 'C121G', 'C121F', 'C121E', 'C121D', 'C121C', 'C121B', 'C121A', 'C47H', 'C47G', 'C47F', 'C47E', 'C47D', 'C47C', 'C47B', 'C47A', 'C1', 'C199', 'C202', 'C203', 'C15', 'C95', 'C18', 'C36', 'C23A', 'C23B', 'C23C', 'C23D', 'C23E']",37
-"Mosfet Array 2 N-Channel (Dual) 40V 9.8A (Ta), 27A (Tc) 3.1W (Ta), 23W (Tc) Surface Mount 8-DFN (5x6) Dual Flag (SO8FL-Dual)",ON Semiconductor,NVMFD5C478NT1G,"['Q11H', 'Q11G', 'Q11F', 'Q11E', 'Q11D', 'Q11C', 'Q11B', 'Q11A', 'Q10H', 'Q10G', 'Q10F', 'Q10E', 'Q10D', 'Q10C', 'Q10B', 'Q10A', 'Q9H', 'Q9G', 'Q9E', 'Q9F', 'Q9D', 'Q9C', 'Q9B', 'Q9A', 'Q7H', 'Q7F', 'Q7E', 'Q7D', 'Q7C', 'Q7B', 'Q7G', 'Q7A']",32
-4.7µF ±10% 6.3V Ceramic Capacitor X7R 0603 (1608 Metric),Samsung,CL10B475KQ8NQNC,"['C131H', 'C131G', 'C131F', 'C131E', 'C131D', 'C131C', 'C131B', 'C131A']",8
-470nF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),Murata,GRM155R60J474KE19D,"['C132H', 'C132G', 'C132F', 'C132E', 'C132D', 'C132C', 'C132B', 'C132A']",8
-,Kemet,C0603C102K5RACTU,"['C58H', 'C58G', 'C58F', 'C58E', 'C58D', 'C58C', 'C58B', 'C58A', 'C96H', 'C96G', 'C96F', 'C96E', 'C96D', 'C96C', 'C96B', 'C96A', 'C97H', 'C97G', 'C97F', 'C97E', 'C97D', 'C97C', 'C97B', 'C97A', 'C123H', 'C123G', 'C123F', 'C123E', 'C123D', 'C123C', 'C123B', 'C123A']",32
-0.22µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),TDK,CGA3E3X7R1H224K080AB,"['C48G', 'C48H', 'C48D', 'C48F', 'C48E', 'C48C', 'C48B', 'C48A', 'C98H', 'C98G', 'C98F', 'C98E', 'C98D', 'C98C', 'C98B', 'C98A', 'C99G', 'C99H', 'C99D', 'C99F', 'C99E', 'C99C', 'C99B', 'C99A', 'C59H', 'C59G', 'C59D', 'C59F', 'C59E', 'C59C', 'C59B', 'C59A']",32
-,Bourns Inc,SMAJ24A,"['D48H', 'D48G', 'D48F', 'D48E', 'D48D', 'D48C', 'D48B', 'D48A', 'D46H', 'D46G', 'D46F', 'D46E', 'D46D', 'D46C', 'D46B', 'D46A', 'D49H', 'D49G', 'D49F', 'D49E', 'D49D', 'D49C', 'D49B', 'D49A', 'D47H', 'D47G', 'D47F', 'D47E', 'D47D', 'D47C', 'D47B', 'D47A', 'D43', 'D78', 'D22', 'D21']",36
-,Stackpole,CSRN2512FK50L0,"['R169H', 'R169G', 'R169F', 'R169E', 'R169D', 'R169C', 'R169B', 'R169A', 'R162H', 'R162G', 'R162D', 'R162F', 'R162E', 'R162C', 'R162B', 'R162A']",16
-4.7µF ±10% 50V Ceramic Capacitor X5R 1206 (3216 Metric),Kemet,C1206C475K5PACTU,"['C61H', 'C61G', 'C61F', 'C61E', 'C61D', 'C61C', 'C61B', 'C61A', 'C125H', 'C125G', 'C125F', 'C125E', 'C125D', 'C125C', 'C125B', 'C125A']",16
-"470µF 50V Aluminum Electrolytic Capacitors Radial, Can - SMD 80 mOhm @ 100kHz 3500 Hrs @ 125°C",Nichicon,UCZ1H471MNQ1MS,"['C152H', 'C152G', 'C152F', 'C152E', 'C152D', 'C152C', 'C152B', 'C152A']",8
-"4.7k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",YAGEO,RC0402FR-074K7L,"['R16H', 'R16G', 'R16F', 'R16E', 'R16D', 'R16C', 'R16B', 'R16A', 'R18E', 'R18H', 'R18G', 'R18F', 'R18D', 'R18C', 'R18B', 'R18A', 'R90', 'R62', 'R80']",19
-,Yageo,RC0402JR-072R2L,"['R107H', 'R107G', 'R107F', 'R107E', 'R107D', 'R107C', 'R107B', 'R107A']",8
-,Molex,43045-0412,"['J2H', 'J2G', 'J2F', 'J2E', 'J2D', 'J2C', 'J2B', 'J2A']",8
-0.022µF ±10% 100V Ceramic Capacitor X7R 0603 (1608 Metric),Kemet,C0603C223K1RACTU,"['C124H', 'C124G', 'C124F', 'C124E', 'C124D', 'C124C', 'C124B', 'C124A']",8
-,Trinamic,TMC5160-TA,"['U15A', 'U15B', 'U15C', 'U15D', 'U15E', 'U15F', 'U15H', 'U15G']",8
+Red 635nm LED Indication - Discrete 2.2V 0805 (2012 Metric),Dialight,5988110107F,"['D18', 'D16', 'D17', 'D9', 'LED3', 'LED2', 'LED1', 'LED4', 'D24']",9
+None,Molex,0430450612,['J1'],1
+"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)",Texas Instruments,SN74AHCT125RGYR,"['U10E', 'U10B', 'U10C', 'U10D', 'U10A', 'U2D', 'U2A', 'U2C', 'U2E', 'U2B']",10
+10000pF ±5% 50V Ceramic Capacitor X7R 0402 (1005 Metric),Murata,GRM155R71H103JA88D,"['C30A', 'C30B', 'C30C', 'C30D', 'C30E', 'C12A', 'C12B', 'C12C', 'C12D', 'C12E', 'C77', 'C43', 'C158', 'C157', 'C84', 'C160', 'C216', 'C214', 'C159', 'C86', 'C171', 'C71', 'C40']",23
+None,Vishay Dale,CRCW040247R0FKEDC,"['R88A', 'R88B', 'R88C', 'R88D', 'R88E', 'R163A', 'R163B', 'R163C', 'R163D', 'R163E', 'R163F', 'R163G', 'R163H', 'R116A', 'R116B', 'R116C', 'R116D', 'R116E', 'R116F', 'R116G', 'R116H', 'R86A', 'R86B', 'R86C', 'R86D', 'R86E', 'R86F', 'R86G', 'R86H', 'R170A', 'R170B', 'R170C', 'R170D', 'R170E', 'R170F', 'R170G', 'R170H', 'R168A', 'R168B', 'R168C', 'R168D', 'R168E', 'R168F', 'R168G', 'R168H', 'R84', 'R13', 'R4', 'R93', 'R94', 'R59', 'R89', 'R3', 'R32']",54
+None,Samsung,CL03A104KQ3NNNC,"['C62A', 'C62B', 'C62C', 'C62D', 'C62E', 'C60A', 'C60B', 'C60C', 'C60D', 'C60E', 'C106', 'C149A', 'C149B', 'C149C', 'C149D', 'C149E', 'C149F', 'C149G', 'C149H', 'C207', 'C204', 'C206', 'C215', 'C205', 'C208', 'C217', 'C2', 'C78', 'C91', 'C100', 'C105', 'C67']",32
+None,Maxim,MAX31856MUD,"['U13A', 'U13B', 'U13C', 'U13D', 'U13E']",5
+"2 Positions Header Connector 0.100 (2.54mm) Through Hole, Right Angle Gold",Phoenix Contact,1864286,"['J21A', 'J21B', 'J21C', 'J21D', 'J21E']",5
+0.10µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),Kemet,C0603C104K5RACTU,"['C23A', 'C23B', 'C23C', 'C23D', 'C23E', 'C122A', 'C122B', 'C122C', 'C122D', 'C122E', 'C122F', 'C122G', 'C122H', 'C121A', 'C121B', 'C121C', 'C121D', 'C121E', 'C121F', 'C121G', 'C121H', 'C47A', 'C47B', 'C47C', 'C47D', 'C47E', 'C47F', 'C47G', 'C47H', 'C1', 'C199', 'C202', 'C203', 'C15', 'C95', 'C18', 'C36']",37
+None,Yageo,RC0402FR-071KL,"['R188', 'R187', 'R177', 'R175', 'R176', 'R186', 'R174', 'R189', 'R108A', 'R108B', 'R108C', 'R108D', 'R108E', 'R108F', 'R108G', 'R108H', 'R152', 'R198', 'R197', 'R74', 'R76', 'R19', 'R23', 'R191', 'R193', 'R72', 'R79', 'R33', 'R102', 'R34', 'R36', 'R40', 'R41', 'R71']",34
+Diode Schottky 30V 200mA (DC) Surface Mount SOD-523,Diodes Incorporated,BAT54WX-TP,"['D57', 'D54', 'D50', 'D55', 'D52', 'D56', 'D53', 'D51', 'D20A', 'D20B', 'D20C', 'D20D', 'D20E', 'D20F', 'D20G', 'D20H', 'D19A', 'D19B', 'D19C', 'D19D', 'D19E', 'D19F', 'D19G', 'D19H', 'D12A', 'D12B', 'D12C', 'D12D', 'D12E', 'D12F', 'D12G', 'D12H', 'D40', 'D63', 'D74', 'D60', 'D62', 'D75', 'D61', 'D77', 'D70', 'D30', 'D5', 'D41', 'D76', 'D31', 'D36', 'D38', 'D37', 'D28', 'D29', 'D39']",52
+None,Yageo,RC0402FR-071K8L,"['R185', 'R173', 'R184', 'R172']",4
+None,None,,"['TP2', 'TP8', 'Q12A', 'TP1', 'TP18', 'Q13A', 'TP17', 'P2A', 'P2B', 'P2C', 'P2D', 'P2E', 'P2F', 'P2G', 'P2H', 'TP69', 'TP4', 'TP7']",18
+None,On Semi,NCV8402ADDR2G,"['Q13B', 'Q12B']",2
+"3 Positions Header, Shrouded Connector 0.100 (2.54mm) Through Hole Gold",Molex,0705430002,"['J29', 'J31', 'J30', 'J22', 'J9', 'J5', 'J32', 'J33', 'J6', 'J7', 'J11', 'J10']",12
+VARISTOR 6.8V 10A 0201,TDK,AVRM0603C6R8NT101N,"['RV5A', 'RV5B', 'RV5C', 'RV5D', 'RV5E', 'RV5F', 'RV5G', 'RV5H', 'RV7A', 'RV7B', 'RV7C', 'RV7D', 'RV7E', 'RV7F', 'RV7G', 'RV7H', 'RV6A', 'RV6B', 'RV6C', 'RV6D', 'RV6E', 'RV6F', 'RV6G', 'RV6H', 'RV4', 'RV1', 'RV2', 'RV3']",28
+"Mosfet Array 2 N-Channel (Dual) 40V 9.8A (Ta), 27A (Tc) 3.1W (Ta), 23W (Tc) Surface Mount 8-DFN (5x6) Dual Flag (SO8FL-Dual)",ON Semiconductor,NVMFD5C478NT1G,"['Q11A', 'Q11B', 'Q11C', 'Q11D', 'Q11E', 'Q11F', 'Q11G', 'Q11H', 'Q10A', 'Q10B', 'Q10C', 'Q10D', 'Q10E', 'Q10F', 'Q10G', 'Q10H', 'Q9A', 'Q9B', 'Q9C', 'Q9D', 'Q9E', 'Q9F', 'Q9G', 'Q9H', 'Q7A', 'Q7B', 'Q7C', 'Q7D', 'Q7E', 'Q7F', 'Q7G', 'Q7H']",32
+4.7µF ±10% 6.3V Ceramic Capacitor X7R 0603 (1608 Metric),Samsung,CL10B475KQ8NQNC,"['C131A', 'C131B', 'C131C', 'C131D', 'C131E', 'C131F', 'C131G', 'C131H']",8
+470nF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),Murata,GRM155R60J474KE19D,"['C132A', 'C132B', 'C132C', 'C132D', 'C132E', 'C132F', 'C132G', 'C132H']",8
+None,Kemet,C0603C102K5RACTU,"['C58A', 'C58B', 'C58C', 'C58D', 'C58E', 'C58F', 'C58G', 'C58H', 'C96A', 'C96B', 'C96C', 'C96D', 'C96E', 'C96F', 'C96G', 'C96H', 'C97A', 'C97B', 'C97C', 'C97D', 'C97E', 'C97F', 'C97G', 'C97H', 'C123A', 'C123B', 'C123C', 'C123D', 'C123E', 'C123F', 'C123G', 'C123H']",32
+0.22µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),TDK,CGA3E3X7R1H224K080AB,"['C48A', 'C48B', 'C48C', 'C48D', 'C48E', 'C48F', 'C48G', 'C48H', 'C98A', 'C98B', 'C98C', 'C98D', 'C98E', 'C98F', 'C98G', 'C98H', 'C99A', 'C99B', 'C99C', 'C99D', 'C99E', 'C99F', 'C99G', 'C99H', 'C59A', 'C59B', 'C59C', 'C59D', 'C59E', 'C59F', 'C59G', 'C59H']",32
+None,Bourns Inc,SMAJ24A,"['D48A', 'D48B', 'D48C', 'D48D', 'D48E', 'D48F', 'D48G', 'D48H', 'D46A', 'D46B', 'D46C', 'D46D', 'D46E', 'D46F', 'D46G', 'D46H', 'D49A', 'D49B', 'D49C', 'D49D', 'D49E', 'D49F', 'D49G', 'D49H', 'D47A', 'D47B', 'D47C', 'D47D', 'D47E', 'D47F', 'D47G', 'D47H', 'D43', 'D78', 'D22', 'D21']",36
+None,Stackpole,CSRN2512FK50L0,"['R169A', 'R169B', 'R169C', 'R169D', 'R169E', 'R169F', 'R169G', 'R169H', 'R162A', 'R162B', 'R162C', 'R162D', 'R162E', 'R162F', 'R162G', 'R162H']",16
+4.7µF ±10% 50V Ceramic Capacitor X5R 1206 (3216 Metric),Kemet,C1206C475K5PACTU,"['C61A', 'C61B', 'C61C', 'C61D', 'C61E', 'C61F', 'C61G', 'C61H', 'C125A', 'C125B', 'C125C', 'C125D', 'C125E', 'C125F', 'C125G', 'C125H']",16
+"470µF 50V Aluminum Electrolytic Capacitors Radial, Can - SMD 80 mOhm @ 100kHz 3500 Hrs @ 125°C",Nichicon,UCZ1H471MNQ1MS,"['C152A', 'C152B', 'C152C', 'C152D', 'C152E', 'C152F', 'C152G', 'C152H']",8
+None,None,DNI-R0402TBD,"['R17A', 'R17B', 'R17C', 'R17D', 'R17E', 'R17F', 'R17G', 'R17H', 'R60']",9
+"4.7k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",YAGEO,RC0402FR-074K7L,"['R16A', 'R16B', 'R16C', 'R16D', 'R16E', 'R16F', 'R16G', 'R16H', 'R18A', 'R18B', 'R18C', 'R18D', 'R18E', 'R18F', 'R18G', 'R18H', 'R90', 'R62', 'R80']",19
+None,Yageo,RC0402JR-072R2L,"['R107A', 'R107B', 'R107C', 'R107D', 'R107E', 'R107F', 'R107G', 'R107H']",8
+None,Molex,43045-0412,"['J2A', 'J2B', 'J2C', 'J2D', 'J2E', 'J2F', 'J2G', 'J2H']",8
+0.022µF ±10% 100V Ceramic Capacitor X7R 0603 (1608 Metric),Kemet,C0603C223K1RACTU,"['C124A', 'C124B', 'C124C', 'C124D', 'C124E', 'C124F', 'C124G', 'C124H']",8
+None,Trinamic,TMC5160-TA,"['U15A', 'U15B', 'U15C', 'U15D', 'U15E', 'U15F', 'U15G', 'U15H']",8
+"24 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0724RL,"['R43', 'R42', 'R48', 'R46', 'R45', 'R47', 'R82', 'R83', 'R77']",9
+None,None,NOTAPART-Solder Bridge,"['JP1', 'JP2']",2
+"6.8k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film",Vishay Dale,CRCW04026K80FKED,"['R150', 'R49', 'R151']",3
+"1M Ohm ±5% 0.1W, 1/10W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film",Panasonic,ERJ2GEJ105X,"['R61', 'R28', 'R156']",3
+"3pF ±0.1pF 50V Ceramic Capacitor C0G, NP0 0603 (1608 Metric)",AVX Corporation,06031A3R0BAT2A,"['C41', 'C42']",2
+Optoisolator Transistor Output 3750Vrms 1 Channel 4-SO,TOSHIBA,"TLP293(TPL,E",['U18'],1
+ARM® Cortex®-M3 SAM3X Microcontroller IC 32-Bit 84MHz 512KB (512K x 8) FLASH 144-LQFP (20x20),Atmel,ATSAM3X8EA-AU,"['U11B', 'U11A', 'U11C']",3
+"100k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Samsung,RC1005F104CS,"['R51', 'R35', 'R22', 'R190', 'R75', 'R192', 'R73', 'R63', 'R78', 'R158', 'R58', 'R31', 'R38', 'R37']",14
+"USB Digital Isolator 2500Vrms 2 Channel 12Mbps 25kV/µs CMTI 16-SOIC (0.295, 7.50mm Width)",Analog Devices,ADUM3160BRWZ-RL,['U9'],1
+TVS DIODE 5.5VWM SOT886,NXP,"PRTR5V0U2F,115",['D27'],1
+2 Line Common Mode Choke Surface Mount 90 Ohm @ 100MHz 330mA DCR 350 mOhm,Murata,DLW21HN900SQ2L,['L5'],1
+Bipolar (BJT) Transistor NPN 40V 200mA 300MHz 150mW Surface Mount SOT-523,Diodes Incorporated,MMBT3904T-7-F,['Q8'],1
+"USB - B USB 2.0 Receptacle Connector 4 Position Through Hole, Right Angle",Amphenol FCI,61729-0010BLF,['J8'],1
+1µF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),Murata,GRM155R60J105KE19D,"['C32', 'C34', 'C24']",3
+"10pF ±5% 50V Ceramic Capacitor C0G, NP0 0402 (1005 Metric)",Samsung,CL05C100JB5NNNC,['C49'],1
+"12MHz ±30ppm Crystal 13pF 60 Ohm -20°C ~ 70°C Surface Mount 4-SMD, No Lead (DFN, LCC)",CTS,405C35B12M00000,['X1'],1
+FERRITE BEAD 120 OHM 0603 1LN,Samsung,CIS10P121AC,"['FB29', 'FB28', 'FB27', 'FB30', 'FB26']",5
+"MULTICOMP  2211S-03G  Board-To-Board Connector, 2.54 mm, 3 Contacts, Header, 2211S Series, Through Hole, 1 Rows",Multicomp,2211S-03G,['J24'],1
+TVS DIODE 3.3VWM SOD923,On Semi,ESD9X3.3ST5G,"['D35', 'D34', 'D32', 'D59', 'D13', 'D58', 'D3', 'D33', 'D42', 'D71', 'D65', 'D67', 'D44', 'D68', 'D66', 'D64', 'D72', 'D69', 'D1', 'D73']",20
 "100µF 35V Aluminum Capacitors Radial, Can - SMD 1000 Hrs @ 105°C",Nichicon,UWT1V101MCL1GS,"['C210', 'C25']",2
 10µF ±20% 50V Ceramic Capacitor X5R 1206 (3216 Metric),Murata,490-10756-2-ND,"['C14', 'C93', 'C38', 'C16']",4
 47µF ±10% 10V Ceramic Capacitor X5R 1210 (3225 Metric),Murata,GRM32ER61A476KE20L,"['C5', 'C4']",2
 "37.4 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0737K4L,['R10'],1
 "15K Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Samsung,RC1005F153CS,['R115'],1
 1000pF ±10% 50V Ceramic Capacitor X7R 0402 (1005 Metric),Murata,GRM155R71H102KA01D,"['C35', 'C94', 'C13', 'C17']",4
-,TI,INA381A2IDSGR,['U19'],1
-,,NOTAPART-Fiducial,"['FD4', 'FD5', 'FD3', 'FD7', 'FD6', 'FD2', 'FD1']",7
+None,TI,INA381A2IDSGR,['U19'],1
+None,None,NOTAPART-Fiducial,"['FD4', 'FD5', 'FD3', 'FD7', 'FD6', 'FD2', 'FD1']",7
 Green 566nm LED Indication - Discrete 2V 0805 (2012 Metric),Dialight,5988170107F,['D23'],1
 Linear Voltage Regulator IC Positive Fixed 1 Output 3.3V 500mA 6-TMLF® (1.6x1.6),Microchip,MIC5353-3.3YMT-TR,['U8'],1
-1µF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),Murata,GRM155R60J105KE19D,"['C34', 'C24', 'C32']",3
-,,NOTAPART-Hole,"['H6', 'H5', 'H1', 'H3', 'H2', 'H9', 'H4', 'H7', 'H8']",9
-,MCC,SK54B-LTP,['D2'],1
-,TE,4DB-P108-10,['J3'],1
+None,None,NOTAPART-Hole,"['H6', 'H5', 'H1', 'H3', 'H2', 'H9', 'H4', 'H7', 'H8']",9
+None,MCC,SK54B-LTP,['D2'],1
+None,TE,4DB-P108-10,['J3'],1
 Linear Voltage Regulator IC Positive Fixed 1 Output 5V 100mA SOT-89-3,ST,L78L05ABUTR,['U20'],1
-"1M Ohm ±5% 0.1W, 1/10W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film",Panasonic,ERJ2GEJ105X,"['R28', 'R156', 'R61']",3
 Fuse Block 30A 500V 1 Circuit Blade PCB,Keystone,3557-2,['F2'],1
 "10.2 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-0710K2L,['R1'],1
 "Board-To-Board Connector, 2.54 mm, 8 Contacts, Header, 2213S Series, Through Hole, 2 Rows",Multicomp,2213S-08G,['P1'],1
 "0.0 Ohm Jumper 0.1W, 1/10W Chip Resistor 0603 (1608 Metric) Moisture Resistant Thick Film",Bourns,CR0603-J/-000ELF,['R103'],1
 Fuse Block 30A 500V 1 Circuit Blade PCB,Keystone,3557-20,['F1'],1
-,TEXAS INSTRUMENTS,AP331AWG-7,"['U21', 'U6']",2
-,Visha Dale,CRCW040224K0FKEDC,"['R26', 'R154']",2
-,AVX,04025A220JAT2A,['C151'],1
-,,NOTAPART-OSHW LOGO,['LOGO1'],1
+None,TEXAS INSTRUMENTS,AP331AWG-7,"['U21', 'U6']",2
+TBD,TBD,TBD,"['C3', 'C101', 'C90', 'C79', 'C104', 'C64', 'C83', 'C89', 'C102', 'C75', 'C74', 'C87', 'C88', 'C85']",14
+None,Visha Dale,CRCW040224K0FKEDC,"['R26', 'R154']",2
+None,AVX,04025A220JAT2A,['C151'],1
+None,None,NOTAPART-OSHW LOGO,['LOGO1'],1
 4.7µF ±10% 50V Ceramic Capacitor X7R 1210 (3225 Metric),Murata,GRM32ER71H475KA88L,"['C7', 'C6']",2
 "130 kOhms ±5% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402JR-07130KL,"['R157', 'R57']",2
 "Buck Switching Regulator IC Positive Adjustable 0.8V 1 Output 5A 8-PowerSOIC (0.154, 3.90mm Width)",TI,TPS54531DDAR,['U1'],1
-,,DNI-C0402TBD,['C198'],1
+None,None,DNI-C0402TBD,['C198'],1
 "2200pF ±5% 25V Ceramic Capacitor C0G, NP0 0402 (1005 Metric)",Kemet,C0402C222J3GACTU,['C150'],1
-,Stackpole,RMCF0402FT1K40,['R2'],1
-,Bourns,SRP1038A-4R7M,['L1'],1
+None,Stackpole,RMCF0402FT1K40,['R2'],1
+None,Bourns,SRP1038A-4R7M,['L1'],1
 "1.96 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-071K96L,['R5'],1
 "10 mOhms ±1% 0.5W, 1/2W Chip Resistor 0805 (2012 Metric) Automotive AEC-Q200, Current Sense Metal Foil",Susumu,KRL1220E-M-R010-F-T5,['R148'],1
+Tactile Switches R/A SEALED TACT SWITCH,TE,1571610-2,['S1'],1
+"10 (8 + 2) Position Card Connector Secure Digital - microSD™ Surface Mount, Right Angle Gold",Molex,0475710001,['J18'],1
+"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)",TI,SN74LVC125ARGYR,"['U16', 'U17']",2
+Clock Fanout Buffer (Distribution) IC 1:4  8-XFDFN,Nexperia,74AVC9112GTX,['U14'],1
+CAP CER 10UF 6.3V 10% JB 0603,TDK,C1608JB0J106K080AB,"['C53', 'C70', 'C55', 'C37', 'C72', 'C57']",6
+TVS DIODE 5V 9V SOD923,Toshiba,"DF2S6.8FS,L3M",['D45'],1
+Tactile Switch SPST-NO Top Actuated Surface Mount,C&K,KMR741NG ULC LFS,['S2'],1
+"10 Positions Header, Unshrouded Connector 0.050 (1.27mm) Surface Mount Gold",Amphenol FCI,20021121-00010C4LF,['J4'],1
+10 Positions Header Connector 0.100 (2.54mm) Through Hole Gold,On Shore,302-S101,"['J12', 'J28', 'J13']",3
+Yellow 593nm LED Indication - Discrete 2V 0805 (2012 Metric),Dialight,5988140107F,['D25'],1
+"Board-To-Board Connector, 2.54 mm, 24 Contacts, Header, 2213S Series, Through Hole, 2 Rows",Multicomp,2213S-24G,['J20'],1
+IC FLASH 16M SPI 104MHZ 8SOIC,Adesto,AT25SF161-SSHD-T,['U12'],1
 "2 Positions Header, Shrouded Connector 0.100 (2.54mm) Through Hole Gold",Molex,0705430001,"['J15', 'J14', 'J16']",3
 "2.37k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",Yageo,RC0402FR-072K37L,"['R87', 'R92', 'R81', 'R44', 'R91', 'R50']",6
-,Maxim,MAX31856MUD,"['U13A', 'U13B', 'U13C', 'U13D', 'U13E']",5
-"2 Positions Header Connector 0.100 (2.54mm) Through Hole, Right Angle Gold",Phoenix Contact,1864286,"['J21E', 'J21D', 'J21C', 'J21B', 'J21A']",5
-,,NOTAPART-Solder Bridge,"['JP1', 'JP2']",2
-"6.8k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film",Vishay Dale,CRCW04026K80FKED,"['R150', 'R49', 'R151']",3
-"3pF ±0.1pF 50V Ceramic Capacitor C0G, NP0 0603 (1608 Metric)",AVX Corporation,06031A3R0BAT2A,"['C41', 'C42']",2
-Optoisolator Transistor Output 3750Vrms 1 Channel 4-SO,TOSHIBA,"TLP293(TPL,E",['U18'],1
-"USB Digital Isolator 2500Vrms 2 Channel 12Mbps 25kV/µs CMTI 16-SOIC (0.295, 7.50mm Width)",Analog Devices,ADUM3160BRWZ-RL,['U9'],1
-TVS DIODE 5.5VWM SOT886,NXP,"PRTR5V0U2F,115",['D27'],1
-2 Line Common Mode Choke Surface Mount 90 Ohm @ 100MHz 330mA DCR 350 mOhm,Murata,DLW21HN900SQ2L,['L5'],1
-Bipolar (BJT) Transistor NPN 40V 200mA 300MHz 150mW Surface Mount SOT-523,Diodes Incorporated,MMBT3904T-7-F,['Q8'],1
-"USB - B USB 2.0 Receptacle Connector 4 Position Through Hole, Right Angle",Amphenol FCI,61729-0010BLF,['J8'],1
-"10pF ±5% 50V Ceramic Capacitor C0G, NP0 0402 (1005 Metric)",Samsung,CL05C100JB5NNNC,['C49'],1
-"12MHz ±30ppm Crystal 13pF 60 Ohm -20°C ~ 70°C Surface Mount 4-SMD, No Lead (DFN, LCC)",CTS,405C35B12M00000,['X1'],1

--- a/tests/data/archimajor_bom_hierarchical_expected.csv
+++ b/tests/data/archimajor_bom_hierarchical_expected.csv
@@ -1,0 +1,107 @@
+description,designators,manufacturer,part_number,quantity
+"10 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R24', 'R52', 'R27', 'R55', 'R167A', 'R167B', 'R167C', 'R167D', 'R167E', 'R167F', 'R167G', 'R167H', 'R111A', 'R111B', 'R111C', 'R111D', 'R111E', 'R111F', 'R111G', 'R111H', 'R166A', 'R166B', 'R166C', 'R166D', 'R166E', 'R166F', 'R166G', 'R166H', 'R112A', 'R112B', 'R112C', 'R112D', 'R112E', 'R112F', 'R112G', 'R112H', 'R164A', 'R164B', 'R164C', 'R164D', 'R164E', 'R164F', 'R164G', 'R164H', 'R110A', 'R110B', 'R110C', 'R110D', 'R110E', 'R110F', 'R110G', 'R110H', 'R113A', 'R113B', 'R113C', 'R113D', 'R113E', 'R113F', 'R113G', 'R113H', 'R165A', 'R165B', 'R165C', 'R165D', 'R165E', 'R165F', 'R165G', 'R165H']",Yageo,RC0402FR-0710RL,68
+0.10µF ±10% 16V Ceramic Capacitor X7R 0402 (1005 Metric),"['C21', 'C22', 'C19', 'C31', 'C20', 'C213', 'C156', 'C212', 'C155', 'C92', 'C76', 'C33', 'C28', 'C29', 'C169', 'C39', 'C201', 'C26', 'C200', 'C44', 'C68', 'C166', 'C164', 'C81', 'C167', 'C80', 'C46', 'C45', 'C66', 'C51', 'C56', 'C73', 'C54', 'C82', 'C165', 'C65', 'C63', 'C69', 'C52', 'C162', 'C103', 'C161']",Murata,GRM155R71C104KA88D,42
+None,"['TP37', 'TP35', 'TP58', 'TP59', 'TP66', 'TP64', 'TP65', 'TP62', 'TP40', 'TP38', 'TP39', 'TP63', 'TP23A', 'TP23B', 'TP23C', 'TP23D', 'TP23E', 'TP24A', 'TP24B', 'TP24C', 'TP24D', 'TP24E', 'TP11A', 'TP11B', 'TP11C', 'TP11D', 'TP11E', 'TP12A', 'TP12B', 'TP12C', 'TP12D', 'TP12E', 'TP12F', 'TP12G', 'TP12H', 'TP41A', 'TP41B', 'TP41C', 'TP41D', 'TP41E', 'TP41F', 'TP41G', 'TP41H', 'TP34A', 'TP34B', 'TP34C', 'TP34D', 'TP34E', 'TP34F', 'TP34G', 'TP34H', 'TP3A', 'TP3B', 'TP3C', 'TP3D', 'TP3E', 'TP3F', 'TP3G', 'TP3H', 'TP60', 'TP31', 'TP30', 'TP61', 'TP6', 'TP5', 'TP32', 'TP55', 'TP19', 'TP130', 'TP80', 'TP81', 'TP25', 'TP131', 'TP82', 'TP67', 'TP33', 'TP79', 'TP43', 'TP48', 'TP47', 'TP44', 'TP36', 'TP46', 'TP51', 'TP77', 'TP52', 'TP128', 'TP76', 'TP13', 'TP129', 'TP21', 'TP16', 'TP74', 'TP53', 'TP54', 'TP14', 'TP50', 'TP49', 'TP56', 'TP20', 'TP26', 'TP27', 'TP15', 'TP22', 'TP29', 'TP78', 'TP75', 'TP107', 'TP106', 'TP101', 'TP9', 'TP108', 'TP10']",None,NOTAPART-Testpoint,113
+"100 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R21', 'R53', 'R20', 'R25', 'R98', 'R99', 'R181', 'R180', 'R149', 'R142', 'R139', 'R138', 'R153', 'R140', 'R120', 'R136', 'R159', 'R109', 'R135', 'R143', 'R145', 'R144', 'R137', 'R141', 'R133', 'R160', 'R114', 'R161', 'R134']",Yageo,RC0402FR-07100RL,29
+"10k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R30', 'R8', 'R54', 'R39', 'R29', 'R6', 'R9', 'R7', 'R183', 'R101', 'R171', 'R14', 'R182', 'R15', 'R96', 'R12', 'R151', 'R150', 'R119', 'R155', 'R11', 'R56', 'R95', 'R67', 'R68', 'R85', 'R100', 'R70', 'R69', 'R65', 'R64', 'R66', 'R97']",Yageo,RC0402FR-0710KP,33
+TVS DIODE 30VWM SOD323,"['D14', 'D10', 'D11', 'D4', 'D26']",Rohm,RSB39VTE-17,5
+Diode Schottky 100V 3A Surface Mount DO-214AC (HSMA),"['D7', 'D15', 'D8', 'D6']",MCC,SK310A,4
+None,"['C9', 'C10', 'C8', 'C11', 'C209', 'C153', 'C154', 'C211', 'C27', 'C50']",None,DNI-C0603TBD,10
+MOSFET N-CH 40V 100A 8VSON,"['Q1', 'Q3', 'Q2', 'Q4']",TI,CSD18503Q5A,4
+Low-Side Gate Driver IC Non-Inverting SOT-26,"['U4', 'U7', 'U5', 'U3']",Diodes Incorporated,ZXGD3009E6TA,4
+Red 635nm LED Indication - Discrete 2.2V 0805 (2012 Metric),"['D18', 'D16', 'D17', 'D9', 'LED3', 'LED2', 'LED1', 'LED4', 'D24']",Dialight,5988110107F,9
+None,['J1'],Molex,0430450612,1
+"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)","['U10E', 'U10B', 'U10C', 'U10D', 'U10A', 'U2D', 'U2A', 'U2C', 'U2E', 'U2B']",Texas Instruments,SN74AHCT125RGYR,10
+10000pF ±5% 50V Ceramic Capacitor X7R 0402 (1005 Metric),"['C30A', 'C30B', 'C30C', 'C30D', 'C30E', 'C12A', 'C12B', 'C12C', 'C12D', 'C12E', 'C77', 'C43', 'C158', 'C157', 'C84', 'C216', 'C214', 'C159', 'C86', 'C171', 'C71', 'C40']",Murata,GRM155R71H103JA88D,22
+None,"['R88A', 'R88B', 'R88C', 'R88D', 'R88E', 'R163A', 'R163B', 'R163C', 'R163D', 'R163E', 'R163F', 'R163G', 'R163H', 'R116A', 'R116B', 'R116C', 'R116D', 'R116E', 'R116F', 'R116G', 'R116H', 'R86A', 'R86B', 'R86C', 'R86D', 'R86E', 'R86F', 'R86G', 'R86H', 'R170A', 'R170B', 'R170C', 'R170D', 'R170E', 'R170F', 'R170G', 'R170H', 'R168A', 'R168B', 'R168C', 'R168D', 'R168E', 'R168F', 'R168G', 'R168H', 'R84', 'R13', 'R4', 'R93', 'R94', 'R59', 'R89', 'R3', 'R32']",Vishay Dale,CRCW040247R0FKEDC,54
+None,"['C62A', 'C62B', 'C62C', 'C62D', 'C62E', 'C60A', 'C60B', 'C60C', 'C60D', 'C60E', 'C106', 'C149A', 'C149B', 'C149C', 'C149D', 'C149E', 'C149F', 'C149G', 'C149H', 'C207', 'C204', 'C206', 'C215', 'C205', 'C208', 'C217', 'C2', 'C78', 'C91', 'C100', 'C105', 'C67']",Samsung,CL03A104KQ3NNNC,32
+None,"['U13A', 'U13B', 'U13C', 'U13D', 'U13E']",Maxim,MAX31856MUD,5
+"2 Positions Header Connector 0.100 (2.54mm) Through Hole, Right Angle Gold","['J21A', 'J21B', 'J21C', 'J21D', 'J21E']",Phoenix Contact,1864286,5
+0.10µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),"['C23A', 'C23B', 'C23C', 'C23D', 'C23E', 'C122A', 'C122B', 'C122C', 'C122D', 'C122E', 'C122F', 'C122G', 'C122H', 'C121A', 'C121B', 'C121C', 'C121D', 'C121E', 'C121F', 'C121G', 'C121H', 'C47A', 'C47B', 'C47C', 'C47D', 'C47E', 'C47F', 'C47G', 'C47H', 'C1', 'C199', 'C202', 'C203', 'C15', 'C95', 'C18', 'C36']",Kemet,C0603C104K5RACTU,37
+None,"['R188', 'R187', 'R177', 'R175', 'R176', 'R186', 'R174', 'R189', 'R108A', 'R108B', 'R108C', 'R108D', 'R108E', 'R108F', 'R108G', 'R108H', 'R152', 'R198', 'R197', 'R74', 'R76', 'R19', 'R23', 'R191', 'R193', 'R72', 'R79', 'R33', 'R102', 'R34', 'R36', 'R40', 'R41', 'R71']",Yageo,RC0402FR-071KL,34
+Diode Schottky 30V 200mA (DC) Surface Mount SOD-523,"['D57', 'D54', 'D50', 'D55', 'D52', 'D56', 'D53', 'D51', 'D20A', 'D20B', 'D20C', 'D20D', 'D20E', 'D20F', 'D20G', 'D20H', 'D19A', 'D19B', 'D19C', 'D19D', 'D19E', 'D19F', 'D19G', 'D19H', 'D12A', 'D12B', 'D12C', 'D12D', 'D12E', 'D12F', 'D12G', 'D12H', 'D40', 'D63', 'D74', 'D60', 'D62', 'D75', 'D61', 'D77', 'D70', 'D30', 'D5', 'D41', 'D76', 'D31', 'D36', 'D38', 'D37', 'D28', 'D29', 'D39']",Diodes Incorporated,BAT54WX-TP,52
+None,"['R185', 'R173', 'R184', 'R172']",Yageo,RC0402FR-071K8L,4
+None,"['TP2', 'TP8', 'Q12A', 'TP1', 'TP18', 'Q13A', 'TP17', 'P2A', 'P2B', 'P2C', 'P2D', 'P2E', 'P2F', 'P2G', 'P2H', 'TP69', 'TP4', 'TP7']",None,,18
+None,"['Q13B', 'Q12B']",On Semi,NCV8402ADDR2G,2
+"3 Positions Header, Shrouded Connector 0.100 (2.54mm) Through Hole Gold","['J29', 'J31', 'J30', 'J22', 'J9', 'J5', 'J32', 'J33', 'J6', 'J7', 'J11', 'J10']",Molex,0705430002,12
+VARISTOR 6.8V 10A 0201,"['RV5A', 'RV5B', 'RV5C', 'RV5D', 'RV5E', 'RV5F', 'RV5G', 'RV5H', 'RV7A', 'RV7B', 'RV7C', 'RV7D', 'RV7E', 'RV7F', 'RV7G', 'RV7H', 'RV6A', 'RV6B', 'RV6C', 'RV6D', 'RV6E', 'RV6F', 'RV6G', 'RV6H', 'RV4', 'RV1', 'RV2', 'RV3']",TDK,AVRM0603C6R8NT101N,28
+"Mosfet Array 2 N-Channel (Dual) 40V 9.8A (Ta), 27A (Tc) 3.1W (Ta), 23W (Tc) Surface Mount 8-DFN (5x6) Dual Flag (SO8FL-Dual)","['Q11A', 'Q11B', 'Q11C', 'Q11D', 'Q11E', 'Q11F', 'Q11G', 'Q11H', 'Q10A', 'Q10B', 'Q10C', 'Q10D', 'Q10E', 'Q10F', 'Q10G', 'Q10H', 'Q9A', 'Q9B', 'Q9C', 'Q9D', 'Q9E', 'Q9F', 'Q9G', 'Q9H', 'Q7A', 'Q7B', 'Q7C', 'Q7D', 'Q7E', 'Q7F', 'Q7G', 'Q7H']",ON Semiconductor,NVMFD5C478NT1G,32
+4.7µF ±10% 6.3V Ceramic Capacitor X7R 0603 (1608 Metric),"['C131A', 'C131B', 'C131C', 'C131D', 'C131E', 'C131F', 'C131G', 'C131H']",Samsung,CL10B475KQ8NQNC,8
+470nF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),"['C132A', 'C132B', 'C132C', 'C132D', 'C132E', 'C132F', 'C132G', 'C132H']",Murata,GRM155R60J474KE19D,8
+None,"['C58A', 'C58B', 'C58C', 'C58D', 'C58E', 'C58F', 'C58G', 'C58H', 'C96A', 'C96B', 'C96C', 'C96D', 'C96E', 'C96F', 'C96G', 'C96H', 'C97A', 'C97B', 'C97C', 'C97D', 'C97E', 'C97F', 'C97G', 'C97H', 'C123A', 'C123B', 'C123C', 'C123D', 'C123E', 'C123F', 'C123G', 'C123H']",Kemet,C0603C102K5RACTU,32
+0.22µF ±10% 50V Ceramic Capacitor X7R 0603 (1608 Metric),"['C48A', 'C48B', 'C48C', 'C48D', 'C48E', 'C48F', 'C48G', 'C48H', 'C98A', 'C98B', 'C98C', 'C98D', 'C98E', 'C98F', 'C98G', 'C98H', 'C99A', 'C99B', 'C99C', 'C99D', 'C99E', 'C99F', 'C99G', 'C99H', 'C59A', 'C59B', 'C59C', 'C59D', 'C59E', 'C59F', 'C59G', 'C59H']",TDK,CGA3E3X7R1H224K080AB,32
+None,"['D48A', 'D48B', 'D48C', 'D48D', 'D48E', 'D48F', 'D48G', 'D48H', 'D46A', 'D46B', 'D46C', 'D46D', 'D46E', 'D46F', 'D46G', 'D46H', 'D49A', 'D49B', 'D49C', 'D49D', 'D49E', 'D49F', 'D49G', 'D49H', 'D47A', 'D47B', 'D47C', 'D47D', 'D47E', 'D47F', 'D47G', 'D47H', 'D43', 'D78', 'D22', 'D21']",Bourns Inc,SMAJ24A,36
+None,"['R169A', 'R169B', 'R169C', 'R169D', 'R169E', 'R169F', 'R169G', 'R169H', 'R162A', 'R162B', 'R162C', 'R162D', 'R162E', 'R162F', 'R162G', 'R162H']",Stackpole,CSRN2512FK50L0,16
+4.7µF ±10% 50V Ceramic Capacitor X5R 1206 (3216 Metric),"['C61A', 'C61B', 'C61C', 'C61D', 'C61E', 'C61F', 'C61G', 'C61H', 'C125A', 'C125B', 'C125C', 'C125D', 'C125E', 'C125F', 'C125G', 'C125H']",Kemet,C1206C475K5PACTU,16
+"470µF 50V Aluminum Electrolytic Capacitors Radial, Can - SMD 80 mOhm @ 100kHz 3500 Hrs @ 125°C","['C152A', 'C152B', 'C152C', 'C152D', 'C152E', 'C152F', 'C152G', 'C152H']",Nichicon,UCZ1H471MNQ1MS,8
+None,"['R17A', 'R17B', 'R17C', 'R17D', 'R17E', 'R17F', 'R17G', 'R17H', 'R60']",None,DNI-R0402TBD,9
+"4.7k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R16A', 'R16B', 'R16C', 'R16D', 'R16E', 'R16F', 'R16G', 'R16H', 'R18A', 'R18B', 'R18C', 'R18D', 'R18E', 'R18F', 'R18G', 'R18H', 'R90', 'R62', 'R80']",YAGEO,RC0402FR-074K7L,19
+None,"['R107A', 'R107B', 'R107C', 'R107D', 'R107E', 'R107F', 'R107G', 'R107H']",Yageo,RC0402JR-072R2L,8
+None,"['J2A', 'J2B', 'J2C', 'J2D', 'J2E', 'J2F', 'J2G', 'J2H']",Molex,43045-0412,8
+0.022µF ±10% 100V Ceramic Capacitor X7R 0603 (1608 Metric),"['C124A', 'C124B', 'C124C', 'C124D', 'C124E', 'C124F', 'C124G', 'C124H']",Kemet,C0603C223K1RACTU,8
+None,"['U15A', 'U15B', 'U15C', 'U15D', 'U15E', 'U15F', 'U15G', 'U15H']",Trinamic,TMC5160-TA,8
+"24 Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R43', 'R42', 'R48', 'R46', 'R45', 'R47', 'R82', 'R83', 'R77']",Yageo,RC0402FR-0724RL,9
+None,"['JP1', 'JP2']",None,NOTAPART-Solder Bridge,2
+"1M Ohm ±5% 0.1W, 1/10W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film","['R61', 'R28', 'R156']",Panasonic,ERJ2GEJ105X,3
+"3pF ±0.1pF 50V Ceramic Capacitor C0G, NP0 0603 (1608 Metric)","['C41', 'C42']",Samsung,CL10C030BB8NNNC,2
+Optoisolator Transistor Output 3750Vrms 1 Channel 4-SO,['U18'],TOSHIBA,"TLP293(TPL,E",1
+ARM® Cortex®-M3 SAM3X Microcontroller IC 32-Bit 84MHz 512KB (512K x 8) FLASH 144-LQFP (20x20),"['U11B', 'U11A', 'U11C']",Atmel,ATSAM3X8EA-AU,3
+"100k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R51', 'R35', 'R22', 'R190', 'R75', 'R192', 'R73', 'R63', 'R78', 'R158', 'R58', 'R31', 'R38', 'R37']",Samsung,RC1005F104CS,14
+"USB Digital Isolator 2500Vrms 2 Channel 12Mbps 25kV/µs CMTI 16-SOIC (0.295, 7.50mm Width)",['U9'],Analog Devices,ADUM3160BRWZ-RL,1
+TVS DIODE 5.5VWM SOT886,['D27'],NXP,"PRTR5V0U2F,115",1
+2 Line Common Mode Choke Surface Mount 90 Ohm @ 100MHz 330mA DCR 350 mOhm,['L5'],Murata,DLW21HN900SQ2L,1
+Bipolar (BJT) Transistor NPN 40V 200mA 300MHz 150mW Surface Mount SOT-523,['Q8'],Diodes Incorporated,MMBT3904T-7-F,1
+"USB - B USB 2.0 Receptacle Connector 4 Position Through Hole, Right Angle",['J8'],Amphenol FCI,61729-0010BLF,1
+1µF ±10% 6.3V Ceramic Capacitor X5R 0402 (1005 Metric),"['C32', 'C34', 'C24']",Murata,GRM155R60J105KE19D,3
+"10pF ±5% 50V Ceramic Capacitor C0G, NP0 0402 (1005 Metric)",['C49'],Samsung,CL05C100JB5NNNC,1
+"6.8k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Automotive AEC-Q200 Thick Film",['R49'],Vishay Dale,CRCW04026K80FKED,1
+"12MHz ±30ppm Crystal 13pF 60 Ohm -20°C ~ 70°C Surface Mount 4-SMD, No Lead (DFN, LCC)",['X1'],CTS,405C35B12M00000,1
+FERRITE BEAD 120 OHM 0603 1LN,"['FB29', 'FB28', 'FB27', 'FB30', 'FB26']",Samsung,CIS10P121AC,5
+"MULTICOMP  2211S-03G  Board-To-Board Connector, 2.54 mm, 3 Contacts, Header, 2211S Series, Through Hole, 1 Rows",['J24'],Multicomp,2211S-03G,1
+"100µF 35V Aluminum Capacitors Radial, Can - SMD 1000 Hrs @ 105°C","['C210', 'C25']",Nichicon,UWT1V101MCL1GS,2
+10µF ±20% 50V Ceramic Capacitor X5R 1206 (3216 Metric),"['C14', 'C93', 'C38', 'C16']",Murata,490-10756-2-ND,4
+47µF ±10% 10V Ceramic Capacitor X5R 1210 (3225 Metric),"['C5', 'C4']",Murata,GRM32ER61A476KE20L,2
+"37.4 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",['R10'],Yageo,RC0402FR-0737K4L,1
+"15K Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",['R115'],Samsung,RC1005F153CS,1
+1000pF ±10% 50V Ceramic Capacitor X7R 0402 (1005 Metric),"['C35', 'C94', 'C13', 'C17']",Murata,GRM155R71H102KA01D,4
+None,['U19'],TI,INA381A2IDSGR,1
+None,"['FD4', 'FD5', 'FD3', 'FD7', 'FD6', 'FD2', 'FD1']",None,NOTAPART-Fiducial,7
+Green 566nm LED Indication - Discrete 2V 0805 (2012 Metric),['D23'],Dialight,5988170107F,1
+Linear Voltage Regulator IC Positive Fixed 1 Output 3.3V 500mA 6-TMLF® (1.6x1.6),['U8'],Microchip,MIC5353-3.3YMT-TR,1
+None,"['H6', 'H5', 'H1', 'H3', 'H2', 'H9', 'H4', 'H7', 'H8']",None,NOTAPART-Hole,9
+None,['D2'],MCC,SK54B-LTP,1
+None,['J3'],TE,4DB-P108-10,1
+Linear Voltage Regulator IC Positive Fixed 1 Output 5V 100mA SOT-89-3,['U20'],ST,L78L05ABUTR,1
+Fuse Block 30A 500V 1 Circuit Blade PCB,"['F2', 'F1']",Keystone,3557-2,2
+"10.2 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",['R1'],Yageo,RC0402FR-0710K2L,1
+"Board-To-Board Connector, 2.54 mm, 8 Contacts, Header, 2213S Series, Through Hole, 2 Rows",['P1'],Multicomp,2213S-08G,1
+"0.0 Ohm Jumper 0.1W, 1/10W Chip Resistor 0603 (1608 Metric) Moisture Resistant Thick Film",['R103'],Bourns,CR0603-J/-000ELF,1
+None,"['U21', 'U6']",TEXAS INSTRUMENTS,AP331AWG-7,2
+TBD,"['C3', 'C101', 'C90', 'C79', 'C104', 'C64', 'C83', 'C89', 'C102', 'C75', 'C74', 'C87', 'C88', 'C85']",TBD,TBD,14
+None,"['R26', 'R154']",Visha Dale,CRCW040224K0FKEDC,2
+None,['C151'],AVX,04025A220JAT2A,1
+None,['LOGO1'],None,NOTAPART-OSHW LOGO,1
+4.7µF ±10% 50V Ceramic Capacitor X7R 1210 (3225 Metric),"['C7', 'C6']",Murata,GRM32ER71H475KA88L,2
+"130 kOhms ±5% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R157', 'R57']",Yageo,RC0402JR-07130KL,2
+"Buck Switching Regulator IC Positive Adjustable 0.8V 1 Output 5A 8-PowerSOIC (0.154, 3.90mm Width)",['U1'],TI,TPS54531DDAR,1
+None,['C198'],None,DNI-C0402TBD,1
+"2200pF ±5% 25V Ceramic Capacitor C0G, NP0 0402 (1005 Metric)",['C150'],Kemet,C0402C222J3GACTU,1
+None,['R2'],Stackpole,RMCF0402FT1K40,1
+None,['L1'],Bourns,SRP1038A-4R7M,1
+"1.96 kOhms ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film",['R5'],Yageo,RC0402FR-071K96L,1
+"10 mOhms ±1% 0.5W, 1/2W Chip Resistor 0805 (2012 Metric) Automotive AEC-Q200, Current Sense Metal Foil",['R148'],Susumu,KRL1220E-M-R010-F-T5,1
+Tactile Switches R/A SEALED TACT SWITCH,['S1'],TE,1571610-2,1
+"10 (8 + 2) Position Card Connector Secure Digital - microSD™ Surface Mount, Right Angle Gold",['J18'],Molex,0475710001,1
+"Buffer, Non-Inverting 4 Element 1 Bit per Element Push-Pull Output 14-VQFN (3.5x3.5)","['U16', 'U17']",TI,SN74LVC125ARGYR,2
+Clock Fanout Buffer (Distribution) IC 1:4  8-XFDFN,['U14'],Nexperia,74AVC9112GTX,1
+TVS DIODE 3.3VWM SOD923,"['D42', 'D71', 'D65', 'D67', 'D44', 'D68', 'D66', 'D64', 'D72', 'D69', 'D1', 'D73']",On Semi,ESD9X3.3ST5G,12
+CAP CER 10UF 6.3V 10% JB 0603,"['C53', 'C70', 'C55', 'C37', 'C72', 'C57']",TDK,C1608JB0J106K080AB,6
+TVS DIODE 5V 9V SOD923,['D45'],Toshiba,"DF2S6.8FS,L3M",1
+Tactile Switch SPST-NO Top Actuated Surface Mount,['S2'],C&K,KMR741NG ULC LFS,1
+"10 Positions Header, Unshrouded Connector 0.050 (1.27mm) Surface Mount Gold",['J4'],Amphenol FCI,20021121-00010C4LF,1
+10 Positions Header Connector 0.100 (2.54mm) Through Hole Gold,"['J12', 'J28', 'J13']",On Shore,302-S101,3
+Yellow 593nm LED Indication - Discrete 2V 0805 (2012 Metric),['D25'],Dialight,5988140107F,1
+"Board-To-Board Connector, 2.54 mm, 24 Contacts, Header, 2213S Series, Through Hole, 2 Rows",['J20'],Multicomp,2213S-24G,1
+IC FLASH 16M SPI 104MHZ 8SOIC,['U12'],Adesto,AT25SF161-SSHD-T,1
+"2 Positions Header, Shrouded Connector 0.100 (2.54mm) Through Hole Gold","['J15', 'J14', 'J16']",Molex,0705430001,3
+"2.37k Ohm ±1% 0.063W, 1/16W Chip Resistor 0402 (1005 Metric) Moisture Resistant Thick Film","['R87', 'R92', 'R81', 'R44', 'R91', 'R50']",Yageo,RC0402FR-072K37L,6

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,7 +69,6 @@ def test_bom_generation(request, instance):
         instance,
         repo,
         "Archimajor.PrjPcb",
-        "Archimajor.PcbDoc",
         attributes_mapping,
         # We hard-code a ref so that this test is reproducible.
         ref="95719adde8107958bf40467ee092c45b6ddaba00",
@@ -126,7 +125,6 @@ def test_bom_generation_with_odd_line_endings(request, instance):
         instance,
         repo,
         "Archimajor.PrjPcb",
-        "Archimajor.PcbDoc",
         attributes_mapping,
         # Note that ref here is the branch, not a commit sha as in the previous
         # test.


### PR DESCRIPTION
Closes #55.

This change removes the `pcbdoc_file` path from the `generate_bom_for_altium` util, and updates the logic to build and traverse the hierarchy of schdoc files instead. This is a breaking change, as the public api of the library has changed. This change also introduces the usage of `configparser` to read the PrjPcb file instead of using a regex, as this will be useful for future changes to the BOM generation. This is the first of three PRs that will change the BOM generation function. 

The test file has to be updated because the new method produces the CSV in a different order.