### PR TITLE
fix: Change columns parameter back to a string instead of a file

### DIFF
--- a/examples/generate_bom/README.md
+++ b/examples/generate_bom/README.md
@@ -61,9 +61,8 @@ python3 generate_bom.py "test/test" "test.PrjPcb" --allspice_hub_url "https://my
 
 ### Customizing the Attributes Extracted by the BOM Script
 
-This script relies on a `columns.json` file. This file maps the Component
-Attributes in the SchDoc files to the columns of the BOM. An example for
-`columns.json` is:
+This script relies on columns JSON. This maps the Component Attributes in the
+SchDoc files to the columns of the BOM. An example for columns JSON is:
 
 ```json
 {
@@ -93,10 +92,6 @@ attributes from overriding any of your own. You can use these like:
   "Part Number": ["PART", "_part_id"]
 }
 ```
-
-By default, the script picks up a `columns.json` file from the working
-directory. If you want to keep it in a different place, or rename it, you can
-pass the `--columns` argument to the script to specify where it is.
 
 ## Cost of Goods Sold
 

--- a/examples/generate_bom/generate_bom.py
+++ b/examples/generate_bom/generate_bom.py
@@ -25,12 +25,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("prjpcb_file", help="The path to the PrjPcb file in the source repo.")
     parser.add_argument(
-        "--columns",
+        "--columns-json",
         help=(
-            "A path to a JSON file mapping columns to the attributes they are from. See the README "
-            "for more details. Defaults to 'columns.json'."
+            "JSON string mapping columns to the attributes they are from. See the README "
+            "for more details. Defaults to '{}'"
         ),
-        default="columns.json",
+        default="{}",
     )
     parser.add_argument(
         "--source_ref",
@@ -58,9 +58,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    columns_file = args.columns
-    with open(columns_file, "r") as f:
-        columns = json.loads(f.read())
+    columns = json.loads(args.columns_json)
 
     # Use Environment Variables to store your auth token. This keeps your token
     # secure when sharing code.


### PR DESCRIPTION
This is to make it easier to use in CI. Custom docker actions don't support input files. Maybe we'll add the file option back someday.