### PR TITLE
Fix to allow empty string for group by

### DIFF
--- a/examples/generate_bom/generate_bom.py
+++ b/examples/generate_bom/generate_bom.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     repo_owner, repo_name = args.repository.split("/")
     repository = allspice.get_repository(repo_owner, repo_name)
     prjpcb_file = args.prjpcb_file
-    group_by = args.group_by.split(",") if args.group_by is not None else None
+    group_by = args.group_by.split(",") if args.group_by else None
 
     print("Generating BOM...", file=sys.stderr)
 


### PR DESCRIPTION
Using the custom action, it's not easy to omit an option. It's much easier to pass an empty string. This change makes it so that both omitted and empty string for group-by are treated the same.