### PR TITLE
Fix COGS script to work when part number column isn't present

### DIFF
--- a/examples/generate_bom/compute_cogs.py
+++ b/examples/generate_bom/compute_cogs.py
@@ -118,9 +118,7 @@ if __name__ == "__main__":
     with open(args.bom_file, "r") as bom_file:
         bom_csv = csv.DictReader(bom_file)
 
-        parts = [
-            part for part in bom_csv if part.get(PART_NUMBER_COLUMN)
-        ]
+        parts = [part for part in bom_csv if part.get(part_number_column)]
 
     print(f"Computing COGS for {len(parts)} parts", file=sys.stderr)
     print(f"Fetching prices for {len(parts)} parts", file=sys.stderr)

--- a/examples/generate_bom/compute_cogs.py
+++ b/examples/generate_bom/compute_cogs.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         bom_csv = csv.DictReader(bom_file)
 
         parts = [
-            part for part in bom_csv if part[PART_NUMBER_COLUMN] and part[PART_NUMBER_COLUMN] != ""
+            part for part in bom_csv if part.get(PART_NUMBER_COLUMN)
         ]
 
     print(f"Computing COGS for {len(parts)} parts", file=sys.stderr)


### PR DESCRIPTION
Python raises KeyError when a key is looked up with brackets and it's not found.