### PR TITLE
Bump actions versions in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and deploy py-allspice 📦 to PyPI
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install pypa/setuptools
@@ -25,6 +25,6 @@ jobs:
         run: >-
           python -m build
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_DEPLOY_TOKEN }}


### PR DESCRIPTION
Closes #102. I haven't been able to test it for obvious reasons, but from the changelogs I don't see any changes that would break this workflow.