### PR TITLE
Remove invalid flag from pdoc invocation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - run: |
           pip install -r requirements.txt
           pip install -r requirements-test.txt
-      - run: pdoc --html --output-dir docs/ ./allspice/*
+      - run: pdoc --output-dir docs/ ./allspice/*
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/


### PR DESCRIPTION
Fixes a run failure. This was a mistake due to an older version of pdoc - I'd fixed it when I tested the run locally but forgot to change it in the workflow file. 