### PR TITLE
Add API to stream file from repo

### DIFF
--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -397,6 +397,7 @@ class Repository(ApiObject):
     REPO_GET_LATEST_RELEASE = "/repos/{owner}/{repo}/releases/latest"
     REPO_GET_RELEASE_BY_TAG = "/repos/{owner}/{repo}/releases/tags/{tag}"
     REPO_GET_COMMIT_STATUS = "/repos/{owner}/{repo}/statuses/{sha}"
+    REPO_GET_RAW_FILE = "/repos/{owner}/{repo}/raw/{path}"
 
     class ArchiveFormat(Enum):
         """
@@ -927,10 +928,14 @@ class Repository(ApiObject):
         """
         Get the raw, binary data of a single file.
 
-        Note: if the file you are requesting is a text file, you might want to
+        Note 1: if the file you are requesting is a text file, you might want to
         use .decode() on the result to get a string. For example:
 
             content = repo.get_raw_file("file.txt").decode("utf-8")
+
+        Note 2: this method will store the entire file in memory. If you want
+        to download a large file, you might want to use `download_to_file`
+        instead.
 
         See https://hub.allspice.io/api/swagger#/repository/repoGetRawFile
 
@@ -939,9 +944,51 @@ class Repository(ApiObject):
             the default branch is used.
         """
 
-        url = f"/repos/{self.owner.username}/{self.name}/raw/{file_path}"
+        url = self.REPO_GET_RAW_FILE.format(
+            owner=self.owner.username,
+            repo=self.name,
+            path=file_path,
+        )
         params = Util.data_params_for_ref(ref)
         return self.allspice_client.requests_get_raw(url, params=params)
+
+    def download_to_file(
+        self,
+        file_path: str,
+        io: IO,
+        ref: Optional[Ref] = None,
+    ):
+        """
+        Download the binary data of a file to a file-like object.
+
+        Example:
+
+            with open("schematic.DSN", "wb") as f:
+                Repository.download_to_file("Schematics/my_schematic.DSN", f)
+
+        :param file_path: The path to the file in the repository from the root
+            of the repository.
+        :param io: The file-like object to write the data to.
+        """
+
+        url = self.allspice_client._AllSpice__get_url(
+            self.REPO_GET_RAW_FILE.format(
+                owner=self.owner.username,
+                repo=self.name,
+                path=file_path,
+            )
+        )
+        params = Util.data_params_for_ref(ref)
+        response = self.allspice_client.requests.get(
+            url,
+            params=params,
+            headers=self.allspice_client.headers,
+            stream=True,
+        )
+
+        for chunk in response.iter_content(chunk_size=4096):
+            if chunk:
+                io.write(chunk)
 
     def get_generated_json(self, content: Union[Content, str], ref: Optional[Ref] = None) -> dict:
         """

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -957,7 +957,7 @@ class Repository(ApiObject):
         file_path: str,
         io: IO,
         ref: Optional[Ref] = None,
-    ):
+    ) -> None:
         """
         Download the binary data of a file to a file-like object.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import base64
 import datetime
-import os
 import time
 import uuid
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import base64
 import datetime
+import os
 import time
 import uuid
 
@@ -306,6 +307,19 @@ def test_get_raw_file(instance):
     readme_content = repo.get_raw_file("README.md")
     assert len(readme_content) > 0
     assert "descr" in str(readme_content)
+
+
+def test_repo_download_file(instance, tmp_path):
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    filename = uuid.uuid4().hex[:8] + ".md"
+    filepath = tmp_path / filename
+    with open(filepath, "wb") as f:
+        repo.download_to_file("README.md", f)
+    with open(filepath, "rb") as f:
+        readme_content = f.read().decode("utf-8")
+        assert len(readme_content) > 0
+        assert "descr" in readme_content
 
 
 def test_create_file(instance):


### PR DESCRIPTION
Fixes https://github.com/AllSpiceIO/py-allspice/issues/81.

This avoids having to store the entire file in memory when downloading large files.