### PR TITLE
Allow manual deploys to the docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - "*"
 
+  workflow_dispatch:
+
 # security: restrict permissions for CI jobs.
 permissions:
   contents: read


### PR DESCRIPTION
We shouldn't have to tag a release to deploy the docs every time. 

I don't like the [default permissions GitHub has for `workflow_dispatch`,](https://github.com/orgs/community/discussions/26622) but the write access requirement and the protection rule on the GitHub environment should keep us safe.