### PR TITLE
doc: Add link to built pdoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Forked from https://github.com/Langenfeld/py-gitea.
 
 ## Usage
 
+### Docs
+
+See the [documentation site](https://allspiceio.github.io/py-allspice/allspice.html).
+
 ### Examples
 
 Check the [examples directory](https://github.com/AllSpiceIO/py-allspice/tree/main/examples)


### PR DESCRIPTION
Add a link to the built documentation originally introduced in #115.

You may want to also consider adding a website link to the repo.