### PR TITLE
Fix CI typecheck failure due to changed cassettes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,9 @@ jobs:
       # If the test is running on a schedule, the purpose of the test is to
       # ensure py-allspice isn't out of date with the current version of hub, so
       # we'll ignore the casettes.
+      #
+      # If this test run fails, we should update the cassettes manually and
+      # check the changes to see what needs to be changed.
       - name: Test with pytest without using casettes
         if: ${{ github.event_name == 'schedule' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Test with pytest without using casettes
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          python -m pytest --record-mode=rewrite
+          python -m pytest --disable-recording
       # Otherwise, we'll use the casettes to make the tests fast.
       - name: Test with pytest using casettes
         if: ${{ github.event_name != 'schedule' }}
@@ -115,7 +115,7 @@ jobs:
           python ./scripts/generate_attribute_types.py
           ruff format .
           ruff check --fix .
-          git diff --exit-code
+          git diff --exit-code ./allspice/apiobject.py
 
   # We might want to consider moving this to a new workflow if we add addition test jobs
   notifications:

--- a/README.md
+++ b/README.md
@@ -100,5 +100,43 @@ Tests can be run with:
 
 `python3 -m pytest test_api.py`
 
-Make sure to have an instance of AllSpice Hub running on `http://localhost:3000`, and an admin-user token at `.token`.
-The admin user must be named `test`, with email `secondarytest@test.org`.
+Make sure to have an instance of AllSpice Hub running on
+`http://localhost:3000`, and an admin-user token at `.token`. The admin user
+must be named `test`, with email `secondarytest@test.org`.
+
+### Cassettes
+
+We use [pytest-recording](https://github.com/kiwicom/pytest-recording) to
+record cassettes which speed up tests which access the network. By default,
+tests which have been updated to work with pytest-recording will use cassettes.
+To disable using cassettes, run:
+
+```sh
+python -m pytest --disable-recording
+```
+
+The scheduled CI test suite will ignore cassettes using the same command. This
+is to ensure that our cassettes aren't out of date in a way that leads to tests
+passing with them but failing with a live Hub environment. If a scheduled test
+run without the cassettes fails, use:
+
+```sh
+python -m pytest --record-mode=rewrite
+```
+
+To update the cassettes. Double check the changes in the cassettes and make sure
+tests are passing again before pushing the changes.
+
+### Snapshots
+
+We use [syrupy](https://github.com/tophat/syrupy) to snapshot test. This makes
+it easier to assert complex outputs. If you have to update snapshots for a test,
+run:
+
+```sh
+python -m pytest -k <specifier for test> --snapshot-update
+```
+
+When updating snapshots, try to run as few tests as possible to ensure you do
+not update snapshots that are unrelated to your changes, and double check
+snapshot changes to ensure they are what you expect.


### PR DESCRIPTION
The CI typecheck script fails on any differences in the working directory, and is therefore sensitive to minor changes in the cassettes. We should not be failing of diffs in the cassettes for three reasons:

1. The changes are usually minor, such as in the headers, and we shouldn't be sensitive to those;
2. Changes that affect the logic will be tested in the API or Utils tests; and
3. Changes in the API responses that affect the attribute types will be highlighted by diffing the API object file alone.

Therefore, this commit:

1. Completely disables vcr.py in the scheduled tests so that the cassettes are not touched at all; and
2. Diffs only the apiobject.py file to check if the types have changed.