### PR TITLE
Fix Design Review Comments not having an associated repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v3.3.1
+
+### What's Changed
+
+- Fix Design Review Comments not having an associated repo by @shrik450 in #162
+
+  This fixes a bug that made it impossible to make any changes or add
+  attachments to a comment on a design review.
+
+### Internal Changes
+
+- Update ruff requirement from ~=0.4 to ~=0.5 by @dependabot in https://github.com/AllSpiceIO/py-allspice/pull/156
+- Fix CI typecheck failure due to changed cassettes by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/149
+- Move test repo sources to AllSpiceTests org by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/160
+
+**Full Changelog**: https://github.com/AllSpiceIO/py-allspice/compare/v3.3.0...v3.3.1
+
 ## v3.3.0
 
 ### What's Changed

--- a/allspice/__init__.py
+++ b/allspice/__init__.py
@@ -23,7 +23,7 @@ from .apiobject import (
 )
 from .exceptions import AlreadyExistsException, NotFoundException
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 __all__ = [
     "AllSpice",

--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -1529,7 +1529,7 @@ class Comment(ApiObject):
     def parent_url(self) -> str:
         """URL of the parent of this comment (the issue or the pull request)"""
 
-        if self.issue_url is not None:
+        if self.issue_url is not None and self.issue_url != "":
             return self.issue_url
         else:
             return self.pull_request_url

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -714,6 +714,26 @@ def test_get_design_review_comments(instance):
     assert comments[0].body == "This is a test comment"
 
 
+def test_add_design_review_comment_attachment(instance):
+    org = Organization.request(instance, test_org)
+    repo = Repository.request(instance, org.username, test_repo)
+    dr = repo.get_design_reviews()[0]
+    comment = dr.get_comments()[0]
+    attachment = comment.create_attachment(open("requirements.txt", "rb"))
+    assert attachment.name == "requirements.txt"
+    assert attachment.download_count == 0
+
+
+def test_get_design_review_attachments(instance):
+    org = Organization.request(instance, test_org)
+    repo = Repository.request(instance, org.username, test_repo)
+    dr = repo.get_design_reviews()[0]
+    comment = dr.get_comments()[0]
+    attachments = comment.get_attachments()
+    assert len(attachments) > 0
+    assert attachments[0].name == "requirements.txt"
+
+
 def test_repo_create_release(instance):
     org = Organization.request(instance, test_org)
     repo = Repository.request(instance, org.username, test_repo)


### PR DESCRIPTION
It was possible for the `issue_comment` field of a comment on a DR to be a blank string instead of null, which broke the logic that found the associated repository for a comment, which is required for the routes involved in making attachments to comments.

I also bumped the version to tag a patch release with this, as it significantly helps out with a workflow that we're working on.