### PR TITLE
Filter out blank components in list_components

### DIFF
--- a/allspice/utils/list_components.py
+++ b/allspice/utils/list_components.py
@@ -222,7 +222,7 @@ def list_components_for_altium(
 
         components = _apply_variations(components, variant_details, allspice_client.logger)
 
-    return components
+    return _filter_blank_components(components, allspice_client.logger)
 
 
 def list_components_for_orcad(
@@ -314,7 +314,7 @@ def _list_components_multi_page_schematic(
                 component_attributes[attribute["name"]] = attribute["value"]
             components.append(component_attributes)
 
-    return components
+    return _filter_blank_components(components, allspice_client.logger)
 
 
 def _fetch_generated_json(repo: Repository, file_path: str, ref: Ref) -> dict:
@@ -748,5 +748,27 @@ def _apply_variations(
             final_components.append(new_component)
         else:
             final_components.append(component)
+
+    return final_components
+
+
+def _filter_blank_components(
+    components: list[ComponentAttributes],
+    logger: Logger,
+) -> list[ComponentAttributes]:
+    """
+    Remove components that have no attributes, or components for which all
+    attributes are empty strings.
+
+    This funtion also debug logs a warning for components that have no attributes.
+    """
+
+    final_components = []
+
+    for component in components:
+        if not any(component.values()):
+            logger.debug(f"Component {component} has no attributes; skipping.")
+            continue
+        final_components.append(component)
 
     return final_components


### PR DESCRIPTION
For some formats we end up interpreting some non-component elements on the board as components. These do not have any attributes and therefore add a blank row to the bom or an empty object to list_components.

However, since it is possible that there is a user error that leads to some components that shouldn't be blank end up being blank, a debug log has been added to catch that case. The log respects the level of the AllSpice client's logger, which is set to INFO by default.

Closes ID-513.