### PR TITLE
Create and use a log handler to actually set log level

### DIFF
--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import requests
@@ -59,6 +60,11 @@ class AllSpice:
         """
 
         self.logger = logging.getLogger(__name__)
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+        self.logger.addHandler(handler)
         self.logger.setLevel(log_level)
         self.headers = {
             "Content-type": "application/json",


### PR DESCRIPTION
Previously, the `log_level` argument to `AllSpice` didn't actually do anything. Since the logger doesn't have a specified handler, it falls back to the root logger which does not respect the result of `setLogLevel`. This commit actually creates a handler for the allspice client's logger, which enables `setLogLevel` to actually work.