### PR TITLE
Bump version to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v3.7.0
+
+### What's Changed
+
+- Update system capture test snapshots with added component attributes by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/187
+- Update type annotations for 1.22 by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/197
+- Enforce max retries in list_components by @shrik450 in https://github.com/AllSpiceIO/py-allspice/pull/198
+
+  > [!CAUTION]
+  >
+  > This could potentially break your BOM generation if individual files were
+  > taking too long to render.
+
+### Internal Changes
+
+- Update pdoc requirement from ~=14.7 to ~=15.0 by @dependabot in https://github.com/AllSpiceIO/py-allspice/pull/189
+- Update ruff by @kdumontnu in https://github.com/AllSpiceIO/py-allspice/pull/196
+
+**Full Changelog**: https://github.com/AllSpiceIO/py-allspice/compare/v3.6.0...v3.7.0
+
 ## v3.6.0
 
 ### What's Changed

--- a/allspice/__init__.py
+++ b/allspice/__init__.py
@@ -23,7 +23,7 @@ from .apiobject import (
 )
 from .exceptions import AlreadyExistsException, NotFoundException
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 __all__ = [
     "AllSpice",


### PR DESCRIPTION
This is 3.7.0 instead of 4.0.0 despite the potentially breaking nature of the max retries change because that was a bug, and always intended to fail after 5 attempts. However, if we feel like this is serious enough to merit a bump to 4 I can change this PR to do that.