### PR TITLE
Make `has_actions` patchable on Repository

### DIFF
--- a/allspice/apiobject.py
+++ b/allspice/apiobject.py
@@ -673,6 +673,7 @@ class Repository(ApiObject):
         "enable_prune",
         "external_tracker",
         "external_wiki",
+        "has_actions",
         "has_issues",
         "has_projects",
         "has_pull_requests",


### PR DESCRIPTION
This would allow enabling/disabling actions on a repository using:

```py
repo.has_actions = True # or false
repo.commit()
```
