### PR TITLE
Retry BOM gen tests up to 100 times when testing without cassettes

### DIFF
--- a/allspice/utils/list_components.py
+++ b/allspice/utils/list_components.py
@@ -483,7 +483,9 @@ def _fetch_generated_json(repo: Repository, file_path: str, ref: Ref) -> dict:
             attempts += 1
             time.sleep(SLEEP_FOR_GENERATED_JSON)
 
-    raise TimeoutError(f"Failed to fetch JSON for {file_path} after 5 attempts.")
+    raise TimeoutError(
+        f"Failed to fetch JSON for {file_path} after {MAX_RETRIES_FOR_GENERATED_JSON} attempts."
+    )
 
 
 @functools.cache

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,12 @@ def instance(port, client_log_level, pytestconfig):
         # If we're using cassettes, we don't want BOM generation to sleep
         # between requests to wait for the generated JSON to be available.
         list_components.SLEEP_FOR_GENERATED_JSON = 0
+    else:
+        # The CI runner is anemic and often cannot generate the outputs in five
+        # retries, so we set it to a very high number to make it effectively
+        # retry for a fair amount of time if we're not using cassettes. If it
+        # cannot generate even in ~100s, that could indicate a real issue.
+        list_components.MAX_RETRIES_FOR_GENERATED_JSON = 100
 
     try:
         g = AllSpice(


### PR DESCRIPTION
There is a daily CI failure as the CI server cannot generate JSONs in <5s every time. This PR allows py-allspice to keep retrying only when the tests are run without cassettes. As discussed before, ideally we'd have configurable retries, but we'd have to discuss how the configuration for that would look and it would require changes across the stack. This is good enough to get the CI to stop failing.