### PR TITLE
Fix test failure with 1.23

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -680,10 +680,10 @@ def test_edit_issue_comment_attachment(instance):
     issue = repo.get_issues()[0]
     comment = issue.get_comments()[0]
     attachment = comment.get_attachments()[0]
-    comment.edit_attachment(attachment, {"name": "this is a new attachment"})
+    comment.edit_attachment(attachment, {"name": "this is a new attachment.txt"})
     del attachment
     attachment2 = comment.get_attachments()[0]
-    assert attachment2.name == "this is a new attachment"
+    assert attachment2.name == "this is a new attachment.txt"
 
 
 def test_delete_issue_comment_attachment(instance):


### PR DESCRIPTION
1.23 made it so that attachments were validated for mime types even when their filenames were being updated. This broke one of our tests, and therefore the build pipeline is currently broken and won't merge. This commit fixes that failure.