### PR TITLE
ci: fix slack send v2 breaking changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             attachments:
-              - color: "${{ needs.test.result == 'success' && 'good' || needs.test.result == 'failure' && 'danger' || 'warning' }}",
+              - color: "${{ needs.test.result == 'success' && 'good' || needs.test.result == 'failure' && 'danger' || 'warning' }}"
                 fields: 
-                  - title: "py-allspice CI: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+                  - title: "py-allspice CI: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
                     value: "GitHub Action build result: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Slack Notification
         uses: slackapi/slack-github-action@v2
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_CI }}
           webhook-type: incoming-webhook
           payload: |
             attachments:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,20 +146,11 @@ jobs:
       - name: Slack Notification
         uses: slackapi/slack-github-action@v2
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.test.result == 'success' && 'good' || needs.test.result == 'failure' && 'danger' || 'warning' }}",
-                  "fields": [
-                    {
-                      "title": "py-allspice CI: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
-                      "value": "GitHub Action build result: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_DEV_CI }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            attachments:
+              - color: "${{ needs.test.result == 'success' && 'good' || needs.test.result == 'failure' && 'danger' || 'warning' }}",
+                fields: 
+                  - title: "py-allspice CI: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+                    value: "GitHub Action build result: ${{ needs.test.result }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"


### PR DESCRIPTION
### Changes
* [Set incoming-webhook](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0#the-webhook-type-must-be-specified-for-incoming-webhooks)
* [Convert payload to yaml](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0#user-content-payloads-can-now-be-written-in-yaml)