### PR TITLE
feat: Add RenderException with better error messages for rendering failures (ID-4481)

### DIFF
--- a/allspice/__init__.py
+++ b/allspice/__init__.py
@@ -22,11 +22,18 @@ from .apiobject import (
     Team,
     User,
 )
-from .exceptions import AlreadyExistsException, NotFoundException
+from .exceptions import (
+    AlreadyExistsException,
+    APIError,
+    InternalServerException,
+    NotFoundException,
+    RenderException,
+)
 
 __version__ = "4.1.0"
 
 __all__ = [
+    "APIError",
     "AllSpice",
     "AlreadyExistsException",
     "Branch",
@@ -35,11 +42,13 @@ __all__ = [
     "Content",
     "DesignReview",
     "DesignReviewReview",
+    "InternalServerException",
     "Issue",
     "Milestone",
     "NotFoundException",
     "Organization",
     "Release",
+    "RenderException",
     "Repository",
     "Team",
     "User",

--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -10,7 +10,9 @@ from frozendict import frozendict
 from .apiobject import Organization, Repository, Team, User
 from .exceptions import (
     AlreadyExistsException,
+    APIError,
     ConflictException,
+    InternalServerException,
     NotFoundException,
     NotYetGeneratedException,
 )
@@ -105,21 +107,23 @@ class AllSpice:
         return url
 
     def __get(self, endpoint: str, params: Mapping = frozendict()) -> requests.Response:
-        request = self.requests.get(self.__get_url(endpoint), headers=self.headers, params=params)
-        if request.status_code not in [200, 201]:
-            message = f"Received status code: {request.status_code} ({request.url})"
-            if request.status_code in [404]:
+        response = self.requests.get(self.__get_url(endpoint), headers=self.headers, params=params)
+        if response.status_code not in [200, 201]:
+            message = f"Received status code: {response.status_code} ({response.url})"
+            if response.status_code in [404]:
                 raise NotFoundException(message)
-            if request.status_code in [403]:
+            if response.status_code in [403]:
                 raise Exception(
-                    f"Unauthorized: {request.url} - Check your permissions and try again! ({message})"
+                    f"Unauthorized: {response.url} - Check your permissions and try again! ({message})"
                 )
-            if request.status_code in [409]:
+            if response.status_code in [409]:
                 raise ConflictException(message)
-            if request.status_code in [503]:
+            if response.status_code in [503]:
                 raise NotYetGeneratedException(message)
+            if response.status_code in [500]:
+                raise InternalServerException(message, APIError.from_json(response.text))
             raise Exception(message)
-        return request
+        return response
 
     @staticmethod
     def parse_result(result) -> Dict:
@@ -184,20 +188,22 @@ class AllSpice:
     def requests_put(self, endpoint: str, data: Optional[dict] = None):
         if not data:
             data = {}
-        request = self.requests.put(
+        response = self.requests.put(
             self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
         )
-        if request.status_code not in [200, 204]:
-            message = f"Received status code: {request.status_code} ({request.url}) {request.text}"
+        if response.status_code not in [200, 204]:
+            message = (
+                f"Received status code: {response.status_code} ({response.url}) {response.text}"
+            )
             self.logger.error(message)
             raise Exception(message)
 
     def requests_delete(self, endpoint: str, data: Optional[dict] = None):
-        request = self.requests.delete(
+        response = self.requests.delete(
             self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
         )
-        if request.status_code not in [200, 204]:
-            message = f"Received status code: {request.status_code} ({request.url})"
+        if response.status_code not in [200, 204]:
+            message = f"Received status code: {response.status_code} ({response.url})"
             self.logger.error(message)
             raise Exception(message)
 
@@ -232,29 +238,29 @@ class AllSpice:
             args["headers"].pop("Content-type")
             args["files"] = files
 
-        request = self.requests.post(self.__get_url(endpoint), **args)
+        response = self.requests.post(self.__get_url(endpoint), **args)
 
-        if request.status_code not in [200, 201, 202]:
-            if "already exists" in request.text or "e-mail already in use" in request.text:
-                self.logger.warning(request.text)
+        if response.status_code not in [200, 201, 202]:
+            if "already exists" in response.text or "e-mail already in use" in response.text:
+                self.logger.warning(response.text)
                 raise AlreadyExistsException()
-            self.logger.error(f"Received status code: {request.status_code} ({request.url})")
+            self.logger.error(f"Received status code: {response.status_code} ({response.url})")
             self.logger.error(f"With info: {data} ({self.headers})")
-            self.logger.error(f"Answer: {request.text}")
+            self.logger.error(f"Answer: {response.text}")
             raise Exception(
-                f"Received status code: {request.status_code} ({request.url}), {request.text}"
+                f"Received status code: {response.status_code} ({response.url}), {response.text}"
             )
-        return self.parse_result(request)
+        return self.parse_result(response)
 
     def requests_patch(self, endpoint: str, data: dict):
-        request = self.requests.patch(
+        response = self.requests.patch(
             self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
         )
-        if request.status_code not in [200, 201]:
-            error_message = f"Received status code: {request.status_code} ({request.url}) {data}"
+        if response.status_code not in [200, 201]:
+            error_message = f"Received status code: {response.status_code} ({response.url}) {data}"
             self.logger.error(error_message)
             raise Exception(error_message)
-        return self.parse_result(request)
+        return self.parse_result(response)
 
     def get_orgs_public_members_all(self, orgname):
         path = "/orgs/" + orgname + "/public_members"

--- a/allspice/exceptions.py
+++ b/allspice/exceptions.py
@@ -1,3 +1,65 @@
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class APIError:
+    """The body of an AllSpice Hub error response"""
+
+    message: Optional[str]
+    url: Optional[str]
+
+    @classmethod
+    def from_json(cls, text: str) -> Optional["APIError"]:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        message = data.get("message") or None
+        url = data.get("url") or None
+
+        if message is None and url is None:
+            return None
+
+        return cls(message=message, url=url)
+
+
+class InternalServerException(Exception):
+    def __init__(self, message: str, body: Optional[APIError] = None):
+        super().__init__(message)
+        self.body = body
+
+
+class RenderException(Exception):
+    """Raised when a server-side render fails; not retried."""
+
+    @classmethod
+    def from_internal(
+        cls, internal: InternalServerException, file_path: str, ref: Optional[str]
+    ) -> "RenderException":
+        body = internal.body
+        if body and body.message:
+            message = body.message
+        else:
+            message = f"Render failed for {file_path}"
+            if ref is not None:
+                message += f" at ref {ref}"
+
+        # Include a diagnostic url if present (a Hub link to the admin panel, don't include other links like swagger docs),
+        # otherwise just ask them to check Hub logs
+        if body and body.url and "-/admin/" in body.url:
+            message += f"; A diagnostic report for this failure can be downloaded by a site admin at {body.url}."
+        else:
+            message += "; Check AllSpice Hub logs for more information."
+
+        return cls(message)
+
+
 class AlreadyExistsException(Exception):
     pass
 
@@ -27,7 +89,7 @@ class NotYetGeneratedException(Exception):
 
 class RawRequestEndpointMissing(Exception):
     """This ApiObject can only be obtained through other api objects and does not have
-    diret .request method."""
+    direct .request method."""
 
     pass
 

--- a/allspice/exceptions.py
+++ b/allspice/exceptions.py
@@ -9,6 +9,7 @@ class APIError:
 
     message: Optional[str]
     url: Optional[str]
+    category: Optional[str]
 
     @classmethod
     def from_json(cls, text: str) -> Optional["APIError"]:
@@ -22,11 +23,12 @@ class APIError:
 
         message = data.get("message") or None
         url = data.get("url") or None
+        category = data.get("category") or None
 
-        if message is None and url is None:
+        if message is None and url is None and category is None:
             return None
 
-        return cls(message=message, url=url)
+        return cls(message=message, url=url, category=category)
 
 
 class InternalServerException(Exception):
@@ -41,9 +43,13 @@ class RenderException(Exception):
     @classmethod
     def from_internal(
         cls, internal: InternalServerException, file_path: str, ref: Optional[str]
-    ) -> "RenderException":
+    ) -> Optional["RenderException"]:
         body = internal.body
-        if body and body.message:
+
+        if body is None or body.category != "render":
+            return None
+
+        if body.message:
             message = body.message
         else:
             message = f"Render failed for {file_path}"
@@ -52,7 +58,7 @@ class RenderException(Exception):
 
         # Include a diagnostic url if present (a Hub link to the admin panel, don't include other links like swagger docs),
         # otherwise just ask them to check Hub logs
-        if body and body.url and "-/admin/" in body.url:
+        if body.url and "-/admin/" in body.url:
             message += f"; A diagnostic report for this failure can be downloaded by a site admin at {body.url}."
         else:
             message += "; Check AllSpice Hub logs for more information."

--- a/allspice/utils/list_components.py
+++ b/allspice/utils/list_components.py
@@ -325,7 +325,6 @@ def list_components_for_altium(
                 schdoc_path_from_repo_root,
                 ref,
                 params={"use_new_schdoc_renderer": "true"},
-                logger=allspice_client.logger,
             )
         )
         schdoc_jsons[schdoc_path_from_repo_root] = schdoc_json
@@ -346,7 +345,6 @@ def list_components_for_altium(
                 # available.
                 device_sheet_repo.default_branch,
                 params={"use_new_schdoc_renderer": "true"},
-                logger=allspice_client.logger,
             )
         )
         device_sheet_jsons[device_sheet_path.stem] = device_sheet_json
@@ -669,7 +667,7 @@ def _list_components_multi_page_schematic(
     # verify that the provided variant exists and convert to an id
     if variant is not None:
         prj_data = retry_not_yet_generated(
-            repository.get_generated_projectdata, schematic_path, ref, logger=allspice_client.logger
+            repository.get_generated_projectdata, schematic_path, ref
         )
         if "variants" in prj_data:
             for id, name in prj_data["variants"].items():
@@ -680,9 +678,7 @@ def _list_components_multi_page_schematic(
             raise NotFoundException("Variant %s does not exist in design." % variant)
 
     # Get the generated JSON for the schematic.
-    schematic_json = retry_not_yet_generated(
-        repository.get_generated_json, schematic_path, ref, logger=allspice_client.logger
-    )
+    schematic_json = retry_not_yet_generated(repository.get_generated_json, schematic_path, ref)
     pages = schematic_json["pages"]
     components = []
 

--- a/allspice/utils/list_components.py
+++ b/allspice/utils/list_components.py
@@ -325,6 +325,7 @@ def list_components_for_altium(
                 schdoc_path_from_repo_root,
                 ref,
                 params={"use_new_schdoc_renderer": "true"},
+                logger=allspice_client.logger,
             )
         )
         schdoc_jsons[schdoc_path_from_repo_root] = schdoc_json
@@ -345,6 +346,7 @@ def list_components_for_altium(
                 # available.
                 device_sheet_repo.default_branch,
                 params={"use_new_schdoc_renderer": "true"},
+                logger=allspice_client.logger,
             )
         )
         device_sheet_jsons[device_sheet_path.stem] = device_sheet_json
@@ -667,7 +669,7 @@ def _list_components_multi_page_schematic(
     # verify that the provided variant exists and convert to an id
     if variant is not None:
         prj_data = retry_not_yet_generated(
-            repository.get_generated_projectdata, schematic_path, ref
+            repository.get_generated_projectdata, schematic_path, ref, logger=allspice_client.logger
         )
         if "variants" in prj_data:
             for id, name in prj_data["variants"].items():
@@ -678,7 +680,9 @@ def _list_components_multi_page_schematic(
             raise NotFoundException("Variant %s does not exist in design." % variant)
 
     # Get the generated JSON for the schematic.
-    schematic_json = retry_not_yet_generated(repository.get_generated_json, schematic_path, ref)
+    schematic_json = retry_not_yet_generated(
+        repository.get_generated_json, schematic_path, ref, logger=allspice_client.logger
+    )
     pages = schematic_json["pages"]
     components = []
 

--- a/allspice/utils/retry_generated.py
+++ b/allspice/utils/retry_generated.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Callable, Optional, TypeVar, Union
 
@@ -19,7 +18,6 @@ def retry_not_yet_generated(
     file_path: Union[Content, str],
     ref: Optional[Ref] = None,
     params: Optional[dict] = None,
-    logger: Optional[logging.Logger] = None,
 ) -> TReturn:
     """
     Request AllSpice generated endpoints with retries if not yet available
@@ -29,8 +27,6 @@ def retry_not_yet_generated(
     :param file_path: The path to the design document
     :param ref: The git ref to check.
     :param params: Optional parameters to pass to the method.
-    :param logger: Optional logger used to record transient server errors before
-        retrying. Retries are silent if it is omitted.
     :returns: The return value of the method if successful
     """
     attempts = 0
@@ -41,21 +37,14 @@ def retry_not_yet_generated(
             attempts += 1
             time.sleep(SLEEP_FOR_GENERATED)
         except InternalServerException as e:
-            render_error = RenderException.from_internal(
+            render_exception = RenderException.from_internal(
                 e, str(file_path), str(ref) if ref is not None else None
             )
 
-            if render_error is not None:
-                raise render_error from e
-
-            if logger is not None:
-                detail = e.body.message if e.body else None
-                logger.warning(
-                    "Transient server error fetching %s: %s - retrying", file_path, detail or e
-                )
-
-            attempts += 1
-            time.sleep(SLEEP_FOR_GENERATED)
+            if render_exception is not None:
+                raise render_exception from e
+            else:
+                raise
 
     raise TimeoutError(
         f"Failed to fetch JSON for {file_path} after {MAX_RETRIES_FOR_GENERATED} attempts."

--- a/allspice/utils/retry_generated.py
+++ b/allspice/utils/retry_generated.py
@@ -2,7 +2,7 @@ import time
 from typing import Callable, Optional, TypeVar, Union
 
 from ..apiobject import Content, Ref
-from ..exceptions import NotYetGeneratedException
+from ..exceptions import InternalServerException, NotYetGeneratedException, RenderException
 
 MAX_RETRIES_FOR_GENERATED = 10
 """The maximum number of times to retry fetching generated JSON files."""
@@ -36,6 +36,10 @@ def retry_not_yet_generated(
         except NotYetGeneratedException:
             attempts += 1
             time.sleep(SLEEP_FOR_GENERATED)
+        except InternalServerException as e:
+            raise RenderException.from_internal(
+                e, str(file_path), str(ref) if ref is not None else None
+            ) from e
 
     raise TimeoutError(
         f"Failed to fetch JSON for {file_path} after {MAX_RETRIES_FOR_GENERATED} attempts."

--- a/allspice/utils/retry_generated.py
+++ b/allspice/utils/retry_generated.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Callable, Optional, TypeVar, Union
 
@@ -18,6 +19,7 @@ def retry_not_yet_generated(
     file_path: Union[Content, str],
     ref: Optional[Ref] = None,
     params: Optional[dict] = None,
+    logger: Optional[logging.Logger] = None,
 ) -> TReturn:
     """
     Request AllSpice generated endpoints with retries if not yet available
@@ -27,6 +29,8 @@ def retry_not_yet_generated(
     :param file_path: The path to the design document
     :param ref: The git ref to check.
     :param params: Optional parameters to pass to the method.
+    :param logger: Optional logger used to record transient server errors before
+        retrying. Retries are silent if it is omitted.
     :returns: The return value of the method if successful
     """
     attempts = 0
@@ -37,9 +41,21 @@ def retry_not_yet_generated(
             attempts += 1
             time.sleep(SLEEP_FOR_GENERATED)
         except InternalServerException as e:
-            raise RenderException.from_internal(
+            render_error = RenderException.from_internal(
                 e, str(file_path), str(ref) if ref is not None else None
-            ) from e
+            )
+
+            if render_error is not None:
+                raise render_error from e
+
+            if logger is not None:
+                detail = e.body.message if e.body else None
+                logger.warning(
+                    "Transient server error fetching %s: %s - retrying", file_path, detail or e
+                )
+
+            attempts += 1
+            time.sleep(SLEEP_FOR_GENERATED)
 
     raise TimeoutError(
         f"Failed to fetch JSON for {file_path} after {MAX_RETRIES_FOR_GENERATED} attempts."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,12 @@ import pytest
 from syrupy.extensions.json import JSONSnapshotExtension
 
 from allspice import AllSpice
-from allspice.exceptions import NotYetGeneratedException
+from allspice.exceptions import (
+    APIError,
+    InternalServerException,
+    NotYetGeneratedException,
+    RenderException,
+)
 from allspice.utils import list_components, retry_generated
 from allspice.utils.bom_generation import (
     ColumnConfig,
@@ -2027,3 +2032,59 @@ def test_altium_components_list_with_hierarchical_device_sheets_and_annotations_
     components.sort(key=lambda x: x["Designator"])
     assert len(components) == 980
     assert components == json_snapshot
+
+
+def test_api_error_from_json_valid():
+    assert APIError.from_json(
+        '{"message": "Something went wrong", "url": "https://hub.allspice.io/api/swagger"}'
+    ) == APIError("Something went wrong", "https://hub.allspice.io/api/swagger")
+
+
+def test_api_error_from_json_partial():
+    assert APIError.from_json('{"message": "Render failure"}') == APIError("Render failure", None)
+
+
+@pytest.mark.parametrize("text", ["not json", "[1, 2]", "{}", '{"message": "", "url": ""}'])
+def test_api_error_from_json_returns_none(text):
+    assert APIError.from_json(text) is None
+
+
+def test_render_exception_uses_server_message_and_diagnostic_url():
+    internal = InternalServerException(
+        "500", APIError("Render Failed", "https://hub.allspice.io/-/admin/crysknife-reports")
+    )
+    message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
+    assert (
+        message
+        == "Render Failed; A diagnostic report for this failure can be downloaded by a site admin at https://hub.allspice.io/-/admin/crysknife-reports."
+    )
+
+
+def test_render_exception_drops_non_admin_url():
+    internal = InternalServerException(
+        "500", APIError("Something went wrong", "https://hub.allspice.io/api/swagger")
+    )
+    message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
+    assert message == "Something went wrong; Check AllSpice Hub logs for more information."
+
+
+def test_render_exception_fallback_omits_ref_when_none():
+    internal = InternalServerException("500", None)
+    message = str(RenderException.from_internal(internal, "foo.SchDoc", None))
+    assert message == "Render failed for foo.SchDoc; Check AllSpice Hub logs for more information."
+
+
+def test_render_exception_fallback_includes_ref():
+    internal = InternalServerException("500", None)
+    message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
+    assert (
+        message
+        == "Render failed for foo.SchDoc at ref main; Check AllSpice Hub logs for more information."
+    )
+
+
+def test_retry_raises_render_exception_without_retrying():
+    method = MagicMock(side_effect=InternalServerException("500", APIError("", None)))
+    with pytest.raises(RenderException):
+        retry_generated.retry_not_yet_generated(method, "foo.SchDoc", "main")
+    method.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2036,22 +2036,31 @@ def test_altium_components_list_with_hierarchical_device_sheets_and_annotations_
 
 def test_api_error_from_json_valid():
     assert APIError.from_json(
-        '{"message": "Something went wrong", "url": "https://hub.allspice.io/api/swagger"}'
-    ) == APIError("Something went wrong", "https://hub.allspice.io/api/swagger")
+        '{"message": "Something went wrong", "url": "https://hub.allspice.io/api/swagger", "category": "render"}'
+    ) == APIError("Something went wrong", "https://hub.allspice.io/api/swagger", "render")
 
 
 def test_api_error_from_json_partial():
-    assert APIError.from_json('{"message": "Render failure"}') == APIError("Render failure", None)
+    assert APIError.from_json('{"message": "Render failure"}') == APIError(
+        "Render failure", None, None
+    )
 
 
-@pytest.mark.parametrize("text", ["not json", "[1, 2]", "{}", '{"message": "", "url": ""}'])
+def test_api_error_from_json_category_only():
+    assert APIError.from_json('{"category": "render"}') == APIError(None, None, "render")
+
+
+@pytest.mark.parametrize(
+    "text", ["not json", "[1, 2]", "{}", '{"message": "", "url": ""}', '{"category": ""}']
+)
 def test_api_error_from_json_returns_none(text):
     assert APIError.from_json(text) is None
 
 
 def test_render_exception_uses_server_message_and_diagnostic_url():
     internal = InternalServerException(
-        "500", APIError("Render Failed", "https://hub.allspice.io/-/admin/crysknife-reports")
+        "500",
+        APIError("Render Failed", "https://hub.allspice.io/-/admin/crysknife-reports", "render"),
     )
     message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
     assert (
@@ -2062,20 +2071,20 @@ def test_render_exception_uses_server_message_and_diagnostic_url():
 
 def test_render_exception_drops_non_admin_url():
     internal = InternalServerException(
-        "500", APIError("Something went wrong", "https://hub.allspice.io/api/swagger")
+        "500", APIError("Something went wrong", "https://hub.allspice.io/api/swagger", "render")
     )
     message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
     assert message == "Something went wrong; Check AllSpice Hub logs for more information."
 
 
 def test_render_exception_fallback_omits_ref_when_none():
-    internal = InternalServerException("500", None)
+    internal = InternalServerException("500", APIError(None, None, "render"))
     message = str(RenderException.from_internal(internal, "foo.SchDoc", None))
     assert message == "Render failed for foo.SchDoc; Check AllSpice Hub logs for more information."
 
 
 def test_render_exception_fallback_includes_ref():
-    internal = InternalServerException("500", None)
+    internal = InternalServerException("500", APIError(None, None, "render"))
     message = str(RenderException.from_internal(internal, "foo.SchDoc", "main"))
     assert (
         message
@@ -2084,7 +2093,28 @@ def test_render_exception_fallback_includes_ref():
 
 
 def test_retry_raises_render_exception_without_retrying():
-    method = MagicMock(side_effect=InternalServerException("500", APIError("", None)))
+    method = MagicMock(side_effect=InternalServerException("500", APIError("", None, "render")))
     with pytest.raises(RenderException):
         retry_generated.retry_not_yet_generated(method, "foo.SchDoc", "main")
     method.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        APIError("upstream unavailable", None, "infra"),
+    ],
+)
+def test_retry_retries_transient_server_error_then_times_out(body):
+    method = MagicMock(side_effect=InternalServerException("500", body))
+    logger = MagicMock()
+    with (
+        patch.object(retry_generated, "SLEEP_FOR_GENERATED", 0),
+        patch.object(retry_generated, "MAX_RETRIES_FOR_GENERATED", 3),
+    ):
+        with pytest.raises(TimeoutError):
+            retry_generated.retry_not_yet_generated(method, "foo.SchDoc", "main", logger=logger)
+
+    assert method.call_count == 3
+    assert logger.warning.call_count == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2106,15 +2106,8 @@ def test_retry_raises_render_exception_without_retrying():
         APIError("upstream unavailable", None, "infra"),
     ],
 )
-def test_retry_retries_transient_server_error_then_times_out(body):
+def test_retry_raises_internal_server_error_without_retrying(body):
     method = MagicMock(side_effect=InternalServerException("500", body))
-    logger = MagicMock()
-    with (
-        patch.object(retry_generated, "SLEEP_FOR_GENERATED", 0),
-        patch.object(retry_generated, "MAX_RETRIES_FOR_GENERATED", 3),
-    ):
-        with pytest.raises(TimeoutError):
-            retry_generated.retry_not_yet_generated(method, "foo.SchDoc", "main", logger=logger)
-
-    assert method.call_count == 3
-    assert logger.warning.call_count == 3
+    with pytest.raises(InternalServerException):
+        retry_generated.retry_not_yet_generated(method, "foo.SchDoc", "main")
+    method.assert_called_once()


### PR DESCRIPTION
# Summary 

This is just some light cleanup work coming out of investigation into ID-4481, not directly part of the ticket. This bug could already be closed, but cleaning up the error messages could make it more obvious where the error actually is next time

# Details

- Add Exception classes for internal server errors from the API with body parsing
- Map these InternalServerExceptions to RenderExceptions in the right places with better error messages and diagnostic URLs when available. 
- Retry non-render classified transient server errors the same as not yet generated errors
- Rename `request` to `response` in the HTTP layer for HTTPResponses - this was throwing me off when I was working through these and wanted to clean it up while I was here with eyes on it

# Future Work

Right now, 500s have their error messages stripped off in production for non-admin users (and actions users don't have admin permissions). So they won't make it through yet, but this work gives them more helpful fallback messages and once I'm able to improve messages from the Hub side they should make their way here. This also prepares for sending diagnostic bundle URLs as part of the error and being able to know when to show them, but this will require Hub-side follow up as well. This work also assumes a new `category` of `"render"` on rendering specific server errors, this will need to be built in Hub first before it lands here, working on that now.