### PR TITLE
Add configurable retries

### DIFF
--- a/allspice/allspice.py
+++ b/allspice/allspice.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 import requests
 import urllib3
 from frozendict import frozendict
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 from .apiobject import Organization, Repository, Team, User
 from .exceptions import (
@@ -17,6 +19,24 @@ from .exceptions import (
     NotYetGeneratedException,
 )
 from .ratelimiter import RateLimitedSession
+
+DEFAULT_RETRY = Retry(
+    total=6,
+    backoff_factor=1.0,
+    backoff_max=30.0,
+    backoff_jitter=3.0,
+    # Only retry on 429s (server rate limiting) and 502 (gateway errors).
+    # However, urllib3 additionally retries 413s and 503s that carry a
+    # Retry-After header, which also covers Hub's behaviour of returning 503s
+    # with Retry-After when a generated file is not ready yet.
+    status_forcelist=frozenset({429, 502}),
+    # Retry on all verbs, including verbs that can mutate server state. This is
+    # why we only retry on the two error codes above.
+    allowed_methods=None,
+    # py-allspice has its own mechanism to convert error messages into
+    # exceptions, so we don't want urllib3 to raise on 429s or 502s.
+    raise_on_status=False,
+)
 
 
 class AllSpice:
@@ -39,6 +59,7 @@ class AllSpice:
         verify=True,
         log_level="INFO",
         ratelimiting=(100, 60),
+        retry: Union[Retry, int, None] = DEFAULT_RETRY,
         use_new_schdoc_renderer: Optional[bool] = None,
     ):
         """Initializing an instance of the AllSpice Hub Client
@@ -61,6 +82,19 @@ class AllSpice:
                 If None, no rate limiting is applied. By default, 100 calls
                 per minute are allowed.
 
+            retry (Retry, int, None): Set a retry policy for requests using a
+                urllib3 Retry object, an integer for the number of retries, or None
+                for no retries. This happens before py-allspice's own rate limiter.
+                The default is to retry all methods (even mutating methods)
+                only on 429s and 502s up to 6 times with exponential backoff
+                and jitter.
+
+                NOTE: AllSpice Hub responds with a 503 and a Retry-After header
+                when a generated file is not ready yet, and urllib3 retries any
+                503 that carries Retry-After. So with retries enabled, fetching
+                generated files transparently waits for generation instead of
+                raising NotYetGeneratedException, until retries are exhausted.
+
             use_new_schdoc_renderer (bool): Allows explicit override for using the new Altium schematic renderer. If set,
             this will take precedence over the default behavior on the AllSpice Hub instance.
         """
@@ -82,6 +116,11 @@ class AllSpice:
         else:
             (max_calls, period) = ratelimiting
             self.requests = RateLimitedSession(max_calls=max_calls, period=period)
+
+        if retry is not None:
+            adapter = HTTPAdapter(max_retries=retry)
+            self.requests.mount("https://", adapter)
+            self.requests.mount("http://", adapter)
 
         # Manage authentification
         if not token_text and not auth:

--- a/allspice/utils/retry_generated.py
+++ b/allspice/utils/retry_generated.py
@@ -20,7 +20,11 @@ def retry_not_yet_generated(
     params: Optional[dict] = None,
 ) -> TReturn:
     """
-    Request AllSpice generated endpoints with retries if not yet available
+    Request AllSpice generated endpoints with retries if not yet available.
+
+    Note: the default Retry mechanism in the allspice client will automatically
+    retry Hub's not yet generated errors up to 6 times, so this is only
+    necessary for cases when you want to retry more than that.
 
     :param method: The request method that may raise
         NotYetGeneratedException, takes file_path and ref as arguments

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests~=2.33
+urllib3~=2.0
 frozendict~=2.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -189,18 +189,6 @@ def test_get_repo_tree(instance):
     assert tree[0].path == "README.md"
 
 
-def test_get_json_before_generated(instance):
-    repo = Repository.request(instance, test_org, test_repo)
-    with pytest.raises(NotYetGeneratedException):
-        repo.get_generated_json("test.pcbdoc")
-
-
-def test_get_svg_before_generated(instance):
-    repo = Repository.request(instance, test_org, test_repo)
-    with pytest.raises(NotYetGeneratedException):
-        repo.get_generated_svg("test.pcbdoc")
-
-
 def test_get_generated_json(instance):
     repo = Repository.request(instance, test_org, test_repo)
     branch = repo.get_branches()[0]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,124 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+
+import pytest
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from allspice import AllSpice, NotFoundException
+from allspice.allspice import DEFAULT_RETRY
+from allspice.exceptions import InternalServerException, NotYetGeneratedException
+
+
+def make_instance(url="https://example.com", **kwargs):
+    return AllSpice(allspice_hub_url=url, token_text="test", **kwargs)
+
+
+def mounted_retries(instance):
+    return instance.requests.get_adapter("https://example.com").max_retries
+
+
+def test_default_retry_is_mounted():
+    assert mounted_retries(make_instance()) is DEFAULT_RETRY
+
+
+def test_custom_retry_is_mounted():
+    retry = Retry(total=2)
+    assert mounted_retries(make_instance(retry=retry)) is retry
+
+
+def test_int_retry_is_mounted():
+    assert mounted_retries(make_instance(retry=3)).total == 3
+
+
+def test_none_opts_out():
+    assert mounted_retries(make_instance(retry=None)).total == HTTPAdapter().max_retries.total
+
+
+@pytest.fixture
+def stub_server():
+    class Handler(BaseHTTPRequestHandler):
+        scripted_responses: ClassVar[list[tuple[int, str]]] = []
+        requests_received: ClassVar[list[str]] = []
+
+        def do_GET(self):
+            self._respond()
+
+        def do_POST(self):
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            self._respond()
+
+        def _respond(self):
+            self.requests_received.append(self.path)
+            status, body = self.scripted_responses[
+                min(len(self.requests_received) - 1, len(self.scripted_responses) - 1)
+            ]
+            self.send_response(status)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(body.encode())
+
+        def log_message(self, format, *args):
+            pass
+
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield Handler, f"http://localhost:{server.server_port}"
+    server.shutdown()
+
+
+@pytest.mark.parametrize("status", [429, 502])
+def test_retries_by_default_then_succeeds(stub_server, status):
+    handler, url = stub_server
+    handler.scripted_responses = [(status, "{}"), (200, json.dumps({"version": "1.0.0"}))]
+
+    instance = make_instance(url=url, ratelimiting=None)
+    assert instance.get_version() == "1.0.0"
+    assert len(handler.requests_received) == 2
+
+
+def test_retries_post_by_default(stub_server):
+    handler, url = stub_server
+    handler.scripted_responses = [(429, "{}"), (200, json.dumps({"id": 1}))]
+
+    instance = make_instance(url=url, ratelimiting=None)
+    assert instance.requests_post("/repos/o/r/issues", data={"title": "t"}) == {"id": 1}
+    assert len(handler.requests_received) == 2
+
+
+@pytest.mark.parametrize(
+    "status,exception",
+    [(503, NotYetGeneratedException), (500, InternalServerException)],
+)
+def test_semantic_statuses_are_not_retried(stub_server, status, exception):
+    handler, url = stub_server
+    handler.scripted_responses = [(status, "{}")]
+
+    instance = make_instance(url=url, ratelimiting=None)
+    with pytest.raises(exception):
+        instance.requests_get("/repos/o/r/allspice_generated/json/file")
+    assert len(handler.requests_received) == 1
+
+
+def test_exhausted_retries_raise_typed_exception(stub_server):
+    handler, url = stub_server
+    handler.scripted_responses = [(404, "{}")]
+
+    instance = make_instance(url=url, ratelimiting=None)
+    with pytest.raises(NotFoundException):
+        instance.requests_get("/repos/nobody/nothing")
+    assert len(handler.requests_received) == 1
+
+
+def test_exhausted_retries_return_final_response(stub_server):
+    handler, url = stub_server
+    handler.scripted_responses = [(429, "{}")]
+
+    retry = DEFAULT_RETRY.new(total=2, backoff_factor=0, backoff_jitter=0)
+    instance = make_instance(url=url, ratelimiting=None, retry=retry)
+    with pytest.raises(Exception, match="429"):
+        instance.requests_get("/version")
+    assert len(handler.requests_received) == 3


### PR DESCRIPTION
In many circumstances, we're running into 429s from Hub when multiple py-allspice scripts use the same token. This commit adds a configurable `Retry` parameter to the client which uses urllib3's [Retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry) util. By default, the client is configured to retry all methods on 429s or 502s (bad gateway) up to 6 times with exponential backoff and jitter.

Notes:

1. Previously, urllib3 was a transitive dep via requests. Since we're now directly using urllib3's own public API, this commit pins it in requirements.txt.
2. Urllib's Retry will also automatically retry on 503s with a Retry-After header, which is what Hub sends when a generated artifact is not present. This means that in most cases you won't need a `retry_not_yet_generated` call after this.